### PR TITLE
Merge from ref

### DIFF
--- a/.github/workflows/sys-update.yml
+++ b/.github/workflows/sys-update.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
       - run: rustup install stable --profile=minimal
       - run: rustup default stable
       - run: cargo install bindgen-cli
@@ -18,18 +18,18 @@ jobs:
         id: make_sys
       - run: git diff
       - if: ${{ steps.make_sys.outputs.tracy-changed }}
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@dff4b11d10ecc84d937fdd0653d8343a88c5b9c4
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - if: ${{ steps.make_sys.outputs.tracy-changed }}
         name: Create Pull Request
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        uses: peter-evans/create-pull-request@88ed63ce144f5372efe9f999d8bb224f582d98d9
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           title: "Update tracy client bindings to ${{ steps.make_sys.outputs.tracy-tag }}"
           body: ''
           delete-branch: true
-          token: ${{ steps.generate-token.outputs.token }}
+          branch: sys-update/${{ steps.make_sys.outputs.tracy-tag }}
           base: main
-          branch-suffix: random

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_toolchain: [nightly, stable, 1.80.0]
+        rust_toolchain: [nightly, stable, 1.81.0]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     timeout-minutes: 20
     steps:

--- a/README.mkd
+++ b/README.mkd
@@ -57,4 +57,5 @@ The following table lists the version correspondence between the libraries.
 | v0.11.0 | 0.23.0         | 0.17.1       | 0.11.1        |
 | v0.11.1 | 0.24.0          | 0.17.3       | 0.11.2        |
 | v0.11.1 | 0.24.3          | 0.18.0       | 0.11.4        |
+| v0.12.0 | 0.25.0          | 0.18.1       | 0.11.4        |
 <!-- AUTO-UPDATE -->

--- a/make_sys.sh
+++ b/make_sys.sh
@@ -17,7 +17,7 @@ TAG="${LAST_RELEASE[0]}"
 TARBALL="${LAST_RELEASE[1]}"
 DESTINATION=/tmp/tracy-$TAG # could use mktemp, but unnecessary complexity.
 
-echo "::set-output name=tracy-tag::$TAG"
+echo "tracy-tag=$TAG" >> "${GITHUB_OUTPUT:-/dev/stdout}"
 mkdir -p "$DESTINATION"
 curl -sL "$TARBALL" -o - | tar -f - -zxC "$DESTINATION"
 BASEDIR=("$DESTINATION"/*)
@@ -57,7 +57,7 @@ sed -i 's/pub type /type /g' 'tracy-client-sys/src/generated.rs'
 # Avoid running the other steps if we haven't really updated tracy (e.g. if bindgen/rustfmt version
 # changed)
 if ! git diff --quiet "tracy-client-sys/tracy"; then
-    echo "::set-output name=tracy-changed::true"
+    echo "tracy-changed=true" >> "${GITHUB_OUTPUT:-/dev/stdout}"
 else
     exit 0
 fi

--- a/make_sys.sh
+++ b/make_sys.sh
@@ -34,21 +34,21 @@ COMMON_BINDGEN_PARAMS=(
 )
 
 bindgen -o "tracy-client-sys/src/generated.rs" \
-  --rust-target 1.80.0 \
+  --rust-target 1.70.0 \
   --allowlist-function='.*[Tt][Rr][Aa][Cc][Yy].*' \
   --allowlist-type='.*[Tt][Rr][Aa][Cc][Yy].*' \
   --blocklist-type='TracyCLockCtx' \
   ${COMMON_BINDGEN_PARAMS[@]}
 
 bindgen -o "tracy-client-sys/src/generated_manual_lifetime.rs" \
-  --rust-target 1.80.0 \
+  --rust-target 1.70.0 \
   --allowlist-function='___tracy_startup_profiler' \
   --allowlist-function='___tracy_shutdown_profiler' \
   ${COMMON_BINDGEN_PARAMS[@]} \
   -DTRACY_MANUAL_LIFETIME
 
 bindgen -o "tracy-client-sys/src/generated_fibers.rs" \
-  --rust-target 1.80.0 \
+  --rust-target 1.70.0 \
   --allowlist-function='___tracy_fiber_enter' \
   --allowlist-function='___tracy_fiber_leave' \
   ${COMMON_BINDGEN_PARAMS[@]} \

--- a/make_sys.sh
+++ b/make_sys.sh
@@ -34,18 +34,21 @@ COMMON_BINDGEN_PARAMS=(
 )
 
 bindgen -o "tracy-client-sys/src/generated.rs" \
+  --rust-target 1.80.0 \
   --allowlist-function='.*[Tt][Rr][Aa][Cc][Yy].*' \
   --allowlist-type='.*[Tt][Rr][Aa][Cc][Yy].*' \
   --blocklist-type='TracyCLockCtx' \
   ${COMMON_BINDGEN_PARAMS[@]}
 
 bindgen -o "tracy-client-sys/src/generated_manual_lifetime.rs" \
+  --rust-target 1.80.0 \
   --allowlist-function='___tracy_startup_profiler' \
   --allowlist-function='___tracy_shutdown_profiler' \
   ${COMMON_BINDGEN_PARAMS[@]} \
   -DTRACY_MANUAL_LIFETIME
 
 bindgen -o "tracy-client-sys/src/generated_fibers.rs" \
+  --rust-target 1.80.0 \
   --allowlist-function='___tracy_fiber_enter' \
   --allowlist-function='___tracy_fiber_leave' \
   ${COMMON_BINDGEN_PARAMS[@]} \

--- a/tracy-client-sys/Cargo.toml
+++ b/tracy-client-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracy-client-sys"
-version = "0.24.3" # AUTO-BUMP
+version = "0.25.0" # AUTO-BUMP
 authors = ["Simonas Kazlauskas <tracy-client-sys@kazlauskas.me>"]
 build = "build.rs"
 license = "(MIT OR Apache-2.0) AND BSD-3-Clause"

--- a/tracy-client-sys/src/generated.rs
+++ b/tracy-client-sys/src/generated.rs
@@ -15,114 +15,39 @@ pub struct ___tracy_source_location_data {
     pub line: u32,
     pub color: u32,
 }
-#[test]
-fn bindgen_test_layout____tracy_source_location_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_source_location_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_source_location_data>(),
-        32usize,
-        concat!("Size of: ", stringify!(___tracy_source_location_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_source_location_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_source_location_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(name)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).function) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(function)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).file) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(file)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).line) as usize - ptr as usize },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(line)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).color) as usize - ptr as usize },
-        28usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_source_location_data),
-            "::",
-            stringify!(color)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_source_location_data"]
+        [::std::mem::size_of::<___tracy_source_location_data>() - 32usize];
+    ["Alignment of ___tracy_source_location_data"]
+        [::std::mem::align_of::<___tracy_source_location_data>() - 8usize];
+    ["Offset of field: ___tracy_source_location_data::name"]
+        [::std::mem::offset_of!(___tracy_source_location_data, name) - 0usize];
+    ["Offset of field: ___tracy_source_location_data::function"]
+        [::std::mem::offset_of!(___tracy_source_location_data, function) - 8usize];
+    ["Offset of field: ___tracy_source_location_data::file"]
+        [::std::mem::offset_of!(___tracy_source_location_data, file) - 16usize];
+    ["Offset of field: ___tracy_source_location_data::line"]
+        [::std::mem::offset_of!(___tracy_source_location_data, line) - 24usize];
+    ["Offset of field: ___tracy_source_location_data::color"]
+        [::std::mem::offset_of!(___tracy_source_location_data, color) - 28usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_c_zone_context {
     pub id: u32,
-    pub active: ::std::os::raw::c_int,
+    pub active: i32,
 }
-#[test]
-fn bindgen_test_layout____tracy_c_zone_context() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_c_zone_context> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_c_zone_context>(),
-        8usize,
-        concat!("Size of: ", stringify!(___tracy_c_zone_context))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_c_zone_context>(),
-        4usize,
-        concat!("Alignment of ", stringify!(___tracy_c_zone_context))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_c_zone_context),
-            "::",
-            stringify!(id)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).active) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_c_zone_context),
-            "::",
-            stringify!(active)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_c_zone_context"][::std::mem::size_of::<___tracy_c_zone_context>() - 8usize];
+    ["Alignment of ___tracy_c_zone_context"]
+        [::std::mem::align_of::<___tracy_c_zone_context>() - 4usize];
+    ["Offset of field: ___tracy_c_zone_context::id"]
+        [::std::mem::offset_of!(___tracy_c_zone_context, id) - 0usize];
+    ["Offset of field: ___tracy_c_zone_context::active"]
+        [::std::mem::offset_of!(___tracy_c_zone_context, active) - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_time_data {
@@ -130,52 +55,18 @@ pub struct ___tracy_gpu_time_data {
     pub queryId: u16,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_time_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_time_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_time_data>(),
-        16usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_time_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_time_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_time_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gpuTime) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_data),
-            "::",
-            stringify!(gpuTime)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).queryId) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_data),
-            "::",
-            stringify!(queryId)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_time_data"][::std::mem::size_of::<___tracy_gpu_time_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_time_data"]
+        [::std::mem::align_of::<___tracy_gpu_time_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_time_data::gpuTime"]
+        [::std::mem::offset_of!(___tracy_gpu_time_data, gpuTime) - 0usize];
+    ["Offset of field: ___tracy_gpu_time_data::queryId"]
+        [::std::mem::offset_of!(___tracy_gpu_time_data, queryId) - 8usize];
+    ["Offset of field: ___tracy_gpu_time_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_time_data, context) - 10usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_zone_begin_data {
@@ -183,164 +74,59 @@ pub struct ___tracy_gpu_zone_begin_data {
     pub queryId: u16,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_zone_begin_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_zone_begin_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_zone_begin_data>(),
-        16usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_zone_begin_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_zone_begin_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_zone_begin_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).srcloc) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_data),
-            "::",
-            stringify!(srcloc)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).queryId) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_data),
-            "::",
-            stringify!(queryId)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_zone_begin_data"]
+        [::std::mem::size_of::<___tracy_gpu_zone_begin_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_zone_begin_data"]
+        [::std::mem::align_of::<___tracy_gpu_zone_begin_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_data::srcloc"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_data, srcloc) - 0usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_data::queryId"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_data, queryId) - 8usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_data, context) - 10usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_zone_begin_callstack_data {
     pub srcloc: u64,
-    pub depth: ::std::os::raw::c_int,
+    pub depth: i32,
     pub queryId: u16,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_zone_begin_callstack_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_zone_begin_callstack_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_zone_begin_callstack_data>(),
-        16usize,
-        concat!(
-            "Size of: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data)
-        )
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_zone_begin_callstack_data>(),
-        8usize,
-        concat!(
-            "Alignment of ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).srcloc) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data),
-            "::",
-            stringify!(srcloc)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).depth) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data),
-            "::",
-            stringify!(depth)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).queryId) as usize - ptr as usize },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data),
-            "::",
-            stringify!(queryId)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        14usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_begin_callstack_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_zone_begin_callstack_data"]
+        [::std::mem::size_of::<___tracy_gpu_zone_begin_callstack_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_zone_begin_callstack_data"]
+        [::std::mem::align_of::<___tracy_gpu_zone_begin_callstack_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_callstack_data::srcloc"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_callstack_data, srcloc) - 0usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_callstack_data::depth"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_callstack_data, depth) - 8usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_callstack_data::queryId"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_callstack_data, queryId) - 12usize];
+    ["Offset of field: ___tracy_gpu_zone_begin_callstack_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_begin_callstack_data, context) - 14usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_zone_end_data {
     pub queryId: u16,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_zone_end_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_zone_end_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_zone_end_data>(),
-        4usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_zone_end_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_zone_end_data>(),
-        2usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_zone_end_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).queryId) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_end_data),
-            "::",
-            stringify!(queryId)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_zone_end_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_zone_end_data"]
+        [::std::mem::size_of::<___tracy_gpu_zone_end_data>() - 4usize];
+    ["Alignment of ___tracy_gpu_zone_end_data"]
+        [::std::mem::align_of::<___tracy_gpu_zone_end_data>() - 2usize];
+    ["Offset of field: ___tracy_gpu_zone_end_data::queryId"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_end_data, queryId) - 0usize];
+    ["Offset of field: ___tracy_gpu_zone_end_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_zone_end_data, context) - 2usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_new_context_data {
@@ -350,72 +136,23 @@ pub struct ___tracy_gpu_new_context_data {
     pub flags: u8,
     pub type_: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_new_context_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_new_context_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_new_context_data>(),
-        16usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_new_context_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_new_context_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_new_context_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gpuTime) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(gpuTime)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).period) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(period)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(context)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).flags) as usize - ptr as usize },
-        13usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(flags)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
-        14usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_new_context_data),
-            "::",
-            stringify!(type_)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_new_context_data"]
+        [::std::mem::size_of::<___tracy_gpu_new_context_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_new_context_data"]
+        [::std::mem::align_of::<___tracy_gpu_new_context_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::gpuTime"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, gpuTime) - 0usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::period"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, period) - 8usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, context) - 12usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::flags"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, flags) - 13usize];
+    ["Offset of field: ___tracy_gpu_new_context_data::type_"]
+        [::std::mem::offset_of!(___tracy_gpu_new_context_data, type_) - 14usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_context_name_data {
@@ -423,52 +160,19 @@ pub struct ___tracy_gpu_context_name_data {
     pub name: *const ::std::os::raw::c_char,
     pub len: u16,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_context_name_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_context_name_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_context_name_data>(),
-        24usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_context_name_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_context_name_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_context_name_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_context_name_data),
-            "::",
-            stringify!(context)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_context_name_data),
-            "::",
-            stringify!(name)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_context_name_data),
-            "::",
-            stringify!(len)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_context_name_data"]
+        [::std::mem::size_of::<___tracy_gpu_context_name_data>() - 24usize];
+    ["Alignment of ___tracy_gpu_context_name_data"]
+        [::std::mem::align_of::<___tracy_gpu_context_name_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_context_name_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_context_name_data, context) - 0usize];
+    ["Offset of field: ___tracy_gpu_context_name_data::name"]
+        [::std::mem::offset_of!(___tracy_gpu_context_name_data, name) - 8usize];
+    ["Offset of field: ___tracy_gpu_context_name_data::len"]
+        [::std::mem::offset_of!(___tracy_gpu_context_name_data, len) - 16usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_calibration_data {
@@ -476,94 +180,36 @@ pub struct ___tracy_gpu_calibration_data {
     pub cpuDelta: i64,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_calibration_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_calibration_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_calibration_data>(),
-        24usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_calibration_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_calibration_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_calibration_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gpuTime) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_calibration_data),
-            "::",
-            stringify!(gpuTime)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cpuDelta) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_calibration_data),
-            "::",
-            stringify!(cpuDelta)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_calibration_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_calibration_data"]
+        [::std::mem::size_of::<___tracy_gpu_calibration_data>() - 24usize];
+    ["Alignment of ___tracy_gpu_calibration_data"]
+        [::std::mem::align_of::<___tracy_gpu_calibration_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_calibration_data::gpuTime"]
+        [::std::mem::offset_of!(___tracy_gpu_calibration_data, gpuTime) - 0usize];
+    ["Offset of field: ___tracy_gpu_calibration_data::cpuDelta"]
+        [::std::mem::offset_of!(___tracy_gpu_calibration_data, cpuDelta) - 8usize];
+    ["Offset of field: ___tracy_gpu_calibration_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_calibration_data, context) - 16usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ___tracy_gpu_time_sync_data {
     pub gpuTime: i64,
     pub context: u8,
 }
-#[test]
-fn bindgen_test_layout____tracy_gpu_time_sync_data() {
-    const UNINIT: ::std::mem::MaybeUninit<___tracy_gpu_time_sync_data> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<___tracy_gpu_time_sync_data>(),
-        16usize,
-        concat!("Size of: ", stringify!(___tracy_gpu_time_sync_data))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<___tracy_gpu_time_sync_data>(),
-        8usize,
-        concat!("Alignment of ", stringify!(___tracy_gpu_time_sync_data))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gpuTime) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_sync_data),
-            "::",
-            stringify!(gpuTime)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).context) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(___tracy_gpu_time_sync_data),
-            "::",
-            stringify!(context)
-        )
-    );
-}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of ___tracy_gpu_time_sync_data"]
+        [::std::mem::size_of::<___tracy_gpu_time_sync_data>() - 16usize];
+    ["Alignment of ___tracy_gpu_time_sync_data"]
+        [::std::mem::align_of::<___tracy_gpu_time_sync_data>() - 8usize];
+    ["Offset of field: ___tracy_gpu_time_sync_data::gpuTime"]
+        [::std::mem::offset_of!(___tracy_gpu_time_sync_data, gpuTime) - 0usize];
+    ["Offset of field: ___tracy_gpu_time_sync_data::context"]
+        [::std::mem::offset_of!(___tracy_gpu_time_sync_data, context) - 8usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __tracy_lockable_context_data {
@@ -595,27 +241,24 @@ extern "C" {
 extern "C" {
     pub fn ___tracy_emit_zone_begin(
         srcloc: *const ___tracy_source_location_data,
-        active: ::std::os::raw::c_int,
+        active: i32,
     ) -> TracyCZoneCtx;
 }
 extern "C" {
     pub fn ___tracy_emit_zone_begin_callstack(
         srcloc: *const ___tracy_source_location_data,
-        depth: ::std::os::raw::c_int,
-        active: ::std::os::raw::c_int,
+        depth: i32,
+        active: i32,
     ) -> TracyCZoneCtx;
 }
 extern "C" {
-    pub fn ___tracy_emit_zone_begin_alloc(
-        srcloc: u64,
-        active: ::std::os::raw::c_int,
-    ) -> TracyCZoneCtx;
+    pub fn ___tracy_emit_zone_begin_alloc(srcloc: u64, active: i32) -> TracyCZoneCtx;
 }
 extern "C" {
     pub fn ___tracy_emit_zone_begin_alloc_callstack(
         srcloc: u64,
-        depth: ::std::os::raw::c_int,
-        active: ::std::os::raw::c_int,
+        depth: i32,
+        active: i32,
     ) -> TracyCZoneCtx;
 }
 extern "C" {
@@ -708,41 +351,34 @@ extern "C" {
     pub fn ___tracy_emit_gpu_time_sync_serial(arg1: ___tracy_gpu_time_sync_data);
 }
 extern "C" {
-    pub fn ___tracy_connected() -> ::std::os::raw::c_int;
+    pub fn ___tracy_connected() -> i32;
 }
 extern "C" {
-    pub fn ___tracy_emit_memory_alloc(
-        ptr: *const ::std::os::raw::c_void,
-        size: usize,
-        secure: ::std::os::raw::c_int,
-    );
+    pub fn ___tracy_emit_memory_alloc(ptr: *const ::std::os::raw::c_void, size: usize, secure: i32);
 }
 extern "C" {
     pub fn ___tracy_emit_memory_alloc_callstack(
         ptr: *const ::std::os::raw::c_void,
         size: usize,
-        depth: ::std::os::raw::c_int,
-        secure: ::std::os::raw::c_int,
+        depth: i32,
+        secure: i32,
     );
 }
 extern "C" {
-    pub fn ___tracy_emit_memory_free(
-        ptr: *const ::std::os::raw::c_void,
-        secure: ::std::os::raw::c_int,
-    );
+    pub fn ___tracy_emit_memory_free(ptr: *const ::std::os::raw::c_void, secure: i32);
 }
 extern "C" {
     pub fn ___tracy_emit_memory_free_callstack(
         ptr: *const ::std::os::raw::c_void,
-        depth: ::std::os::raw::c_int,
-        secure: ::std::os::raw::c_int,
+        depth: i32,
+        secure: i32,
     );
 }
 extern "C" {
     pub fn ___tracy_emit_memory_alloc_named(
         ptr: *const ::std::os::raw::c_void,
         size: usize,
-        secure: ::std::os::raw::c_int,
+        secure: i32,
         name: *const ::std::os::raw::c_char,
     );
 }
@@ -750,52 +386,59 @@ extern "C" {
     pub fn ___tracy_emit_memory_alloc_callstack_named(
         ptr: *const ::std::os::raw::c_void,
         size: usize,
-        depth: ::std::os::raw::c_int,
-        secure: ::std::os::raw::c_int,
+        depth: i32,
+        secure: i32,
         name: *const ::std::os::raw::c_char,
     );
 }
 extern "C" {
     pub fn ___tracy_emit_memory_free_named(
         ptr: *const ::std::os::raw::c_void,
-        secure: ::std::os::raw::c_int,
+        secure: i32,
         name: *const ::std::os::raw::c_char,
     );
 }
 extern "C" {
     pub fn ___tracy_emit_memory_free_callstack_named(
         ptr: *const ::std::os::raw::c_void,
-        depth: ::std::os::raw::c_int,
-        secure: ::std::os::raw::c_int,
+        depth: i32,
+        secure: i32,
         name: *const ::std::os::raw::c_char,
+    );
+}
+extern "C" {
+    pub fn ___tracy_emit_memory_discard(name: *const ::std::os::raw::c_char, secure: i32);
+}
+extern "C" {
+    pub fn ___tracy_emit_memory_discard_callstack(
+        name: *const ::std::os::raw::c_char,
+        secure: i32,
+        depth: i32,
     );
 }
 extern "C" {
     pub fn ___tracy_emit_message(
         txt: *const ::std::os::raw::c_char,
         size: usize,
-        callstack: ::std::os::raw::c_int,
+        callstack_depth: i32,
     );
 }
 extern "C" {
-    pub fn ___tracy_emit_messageL(
-        txt: *const ::std::os::raw::c_char,
-        callstack: ::std::os::raw::c_int,
-    );
+    pub fn ___tracy_emit_messageL(txt: *const ::std::os::raw::c_char, callstack_depth: i32);
 }
 extern "C" {
     pub fn ___tracy_emit_messageC(
         txt: *const ::std::os::raw::c_char,
         size: usize,
         color: u32,
-        callstack: ::std::os::raw::c_int,
+        callstack_depth: i32,
     );
 }
 extern "C" {
     pub fn ___tracy_emit_messageLC(
         txt: *const ::std::os::raw::c_char,
         color: u32,
-        callstack: ::std::os::raw::c_int,
+        callstack_depth: i32,
     );
 }
 extern "C" {
@@ -813,7 +456,7 @@ extern "C" {
         w: u16,
         h: u16,
         offset: u8,
-        flip: ::std::os::raw::c_int,
+        flip: i32,
     );
 }
 extern "C" {
@@ -828,9 +471,9 @@ extern "C" {
 extern "C" {
     pub fn ___tracy_emit_plot_config(
         name: *const ::std::os::raw::c_char,
-        type_: ::std::os::raw::c_int,
-        step: ::std::os::raw::c_int,
-        fill: ::std::os::raw::c_int,
+        type_: i32,
+        step: i32,
+        fill: i32,
         color: u32,
     );
 }
@@ -846,9 +489,7 @@ extern "C" {
     pub fn ___tracy_terminate_lockable_ctx(lockdata: *mut __tracy_lockable_context_data);
 }
 extern "C" {
-    pub fn ___tracy_before_lock_lockable_ctx(
-        lockdata: *mut __tracy_lockable_context_data,
-    ) -> ::std::os::raw::c_int;
+    pub fn ___tracy_before_lock_lockable_ctx(lockdata: *mut __tracy_lockable_context_data) -> i32;
 }
 extern "C" {
     pub fn ___tracy_after_lock_lockable_ctx(lockdata: *mut __tracy_lockable_context_data);
@@ -859,7 +500,7 @@ extern "C" {
 extern "C" {
     pub fn ___tracy_after_try_lock_lockable_ctx(
         lockdata: *mut __tracy_lockable_context_data,
-        acquired: ::std::os::raw::c_int,
+        acquired: i32,
     );
 }
 extern "C" {

--- a/tracy-client-sys/tracy/LICENSE
+++ b/tracy-client-sys/tracy/LICENSE
@@ -1,7 +1,7 @@
 Tracy Profiler (https://github.com/wolfpld/tracy) is licensed under the
 3-clause BSD license.
 
-Copyright (c) 2017-2024, Bartosz Taudul <wolf@nereid.pl>
+Copyright (c) 2017-2025, Bartosz Taudul <wolf@nereid.pl>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tracy-client-sys/tracy/TracyClient.F90
+++ b/tracy-client-sys/tracy/TracyClient.F90
@@ -1,0 +1,1292 @@
+module tracy
+  use, intrinsic :: iso_c_binding, only: c_ptr, c_loc, c_char, c_null_char, &
+    & c_size_t, c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_int, c_float, c_double, c_null_ptr
+  implicit none
+  private
+
+  integer(c_int32_t), parameter, public :: TRACY_PLOTFORMAT_NUMBER = 0
+  integer(c_int32_t), parameter, public :: TRACY_PLOTFORMAT_MEMORY = 1
+  integer(c_int32_t), parameter, public :: TRACY_PLOTFORMAT_PERCENTAGE = 2
+  integer(c_int32_t), parameter, public :: TRACY_PLOTFORMAT_WATT = 3
+
+  character(c_char), parameter, public :: tracy_null_char = c_null_char
+
+  type, bind(C) :: TracyColors_t
+    integer(c_int32_t) :: Snow = int(Z'fffafa', kind=c_int32_t)
+    integer(c_int32_t) :: GhostWhite = int(Z'f8f8ff', kind=c_int32_t)
+    integer(c_int32_t) :: WhiteSmoke = int(Z'f5f5f5', kind=c_int32_t)
+    integer(c_int32_t) :: Gainsboro = int(Z'dcdcdc', kind=c_int32_t)
+    integer(c_int32_t) :: FloralWhite = int(Z'fffaf0', kind=c_int32_t)
+    integer(c_int32_t) :: OldLace = int(Z'fdf5e6', kind=c_int32_t)
+    integer(c_int32_t) :: Linen = int(Z'faf0e6', kind=c_int32_t)
+    integer(c_int32_t) :: AntiqueWhite = int(Z'faebd7', kind=c_int32_t)
+    integer(c_int32_t) :: PapayaWhip = int(Z'ffefd5', kind=c_int32_t)
+    integer(c_int32_t) :: BlanchedAlmond = int(Z'ffebcd', kind=c_int32_t)
+    integer(c_int32_t) :: Bisque = int(Z'ffe4c4', kind=c_int32_t)
+    integer(c_int32_t) :: PeachPuff = int(Z'ffdab9', kind=c_int32_t)
+    integer(c_int32_t) :: NavajoWhite = int(Z'ffdead', kind=c_int32_t)
+    integer(c_int32_t) :: Moccasin = int(Z'ffe4b5', kind=c_int32_t)
+    integer(c_int32_t) :: Cornsilk = int(Z'fff8dc', kind=c_int32_t)
+    integer(c_int32_t) :: Ivory = int(Z'fffff0', kind=c_int32_t)
+    integer(c_int32_t) :: LemonChiffon = int(Z'fffacd', kind=c_int32_t)
+    integer(c_int32_t) :: Seashell = int(Z'fff5ee', kind=c_int32_t)
+    integer(c_int32_t) :: Honeydew = int(Z'f0fff0', kind=c_int32_t)
+    integer(c_int32_t) :: MintCream = int(Z'f5fffa', kind=c_int32_t)
+    integer(c_int32_t) :: Azure = int(Z'f0ffff', kind=c_int32_t)
+    integer(c_int32_t) :: AliceBlue = int(Z'f0f8ff', kind=c_int32_t)
+    integer(c_int32_t) :: Lavender = int(Z'e6e6fa', kind=c_int32_t)
+    integer(c_int32_t) :: LavenderBlush = int(Z'fff0f5', kind=c_int32_t)
+    integer(c_int32_t) :: MistyRose = int(Z'ffe4e1', kind=c_int32_t)
+    integer(c_int32_t) :: White = int(Z'ffffff', kind=c_int32_t)
+    integer(c_int32_t) :: Black = int(Z'000000', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSlateGray = int(Z'2f4f4f', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSlateGrey = int(Z'2f4f4f', kind=c_int32_t)
+    integer(c_int32_t) :: DimGray = int(Z'696969', kind=c_int32_t)
+    integer(c_int32_t) :: DimGrey = int(Z'696969', kind=c_int32_t)
+    integer(c_int32_t) :: SlateGray = int(Z'708090', kind=c_int32_t)
+    integer(c_int32_t) :: SlateGrey = int(Z'708090', kind=c_int32_t)
+    integer(c_int32_t) :: LightSlateGray = int(Z'778899', kind=c_int32_t)
+    integer(c_int32_t) :: LightSlateGrey = int(Z'778899', kind=c_int32_t)
+    integer(c_int32_t) :: Gray = int(Z'bebebe', kind=c_int32_t)
+    integer(c_int32_t) :: Grey = int(Z'bebebe', kind=c_int32_t)
+    integer(c_int32_t) :: X11Gray = int(Z'bebebe', kind=c_int32_t)
+    integer(c_int32_t) :: X11Grey = int(Z'bebebe', kind=c_int32_t)
+    integer(c_int32_t) :: WebGray = int(Z'808080', kind=c_int32_t)
+    integer(c_int32_t) :: WebGrey = int(Z'808080', kind=c_int32_t)
+    integer(c_int32_t) :: LightGrey = int(Z'd3d3d3', kind=c_int32_t)
+    integer(c_int32_t) :: LightGray = int(Z'd3d3d3', kind=c_int32_t)
+    integer(c_int32_t) :: MidnightBlue = int(Z'191970', kind=c_int32_t)
+    integer(c_int32_t) :: Navy = int(Z'000080', kind=c_int32_t)
+    integer(c_int32_t) :: NavyBlue = int(Z'000080', kind=c_int32_t)
+    integer(c_int32_t) :: CornflowerBlue = int(Z'6495ed', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSlateBlue = int(Z'483d8b', kind=c_int32_t)
+    integer(c_int32_t) :: SlateBlue = int(Z'6a5acd', kind=c_int32_t)
+    integer(c_int32_t) :: MediumSlateBlue = int(Z'7b68ee', kind=c_int32_t)
+    integer(c_int32_t) :: LightSlateBlue = int(Z'8470ff', kind=c_int32_t)
+    integer(c_int32_t) :: MediumBlue = int(Z'0000cd', kind=c_int32_t)
+    integer(c_int32_t) :: RoyalBlue = int(Z'4169e1', kind=c_int32_t)
+    integer(c_int32_t) :: Blue = int(Z'0000ff', kind=c_int32_t)
+    integer(c_int32_t) :: DodgerBlue = int(Z'1e90ff', kind=c_int32_t)
+    integer(c_int32_t) :: DeepSkyBlue = int(Z'00bfff', kind=c_int32_t)
+    integer(c_int32_t) :: SkyBlue = int(Z'87ceeb', kind=c_int32_t)
+    integer(c_int32_t) :: LightSkyBlue = int(Z'87cefa', kind=c_int32_t)
+    integer(c_int32_t) :: SteelBlue = int(Z'4682b4', kind=c_int32_t)
+    integer(c_int32_t) :: LightSteelBlue = int(Z'b0c4de', kind=c_int32_t)
+    integer(c_int32_t) :: LightBlue = int(Z'add8e6', kind=c_int32_t)
+    integer(c_int32_t) :: PowderBlue = int(Z'b0e0e6', kind=c_int32_t)
+    integer(c_int32_t) :: PaleTurquoise = int(Z'afeeee', kind=c_int32_t)
+    integer(c_int32_t) :: DarkTurquoise = int(Z'00ced1', kind=c_int32_t)
+    integer(c_int32_t) :: MediumTurquoise = int(Z'48d1cc', kind=c_int32_t)
+    integer(c_int32_t) :: Turquoise = int(Z'40e0d0', kind=c_int32_t)
+    integer(c_int32_t) :: Cyan = int(Z'00ffff', kind=c_int32_t)
+    integer(c_int32_t) :: Aqua = int(Z'00ffff', kind=c_int32_t)
+    integer(c_int32_t) :: LightCyan = int(Z'e0ffff', kind=c_int32_t)
+    integer(c_int32_t) :: CadetBlue = int(Z'5f9ea0', kind=c_int32_t)
+    integer(c_int32_t) :: MediumAquamarine = int(Z'66cdaa', kind=c_int32_t)
+    integer(c_int32_t) :: Aquamarine = int(Z'7fffd4', kind=c_int32_t)
+    integer(c_int32_t) :: DarkGreen = int(Z'006400', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOliveGreen = int(Z'556b2f', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSeaGreen = int(Z'8fbc8f', kind=c_int32_t)
+    integer(c_int32_t) :: SeaGreen = int(Z'2e8b57', kind=c_int32_t)
+    integer(c_int32_t) :: MediumSeaGreen = int(Z'3cb371', kind=c_int32_t)
+    integer(c_int32_t) :: LightSeaGreen = int(Z'20b2aa', kind=c_int32_t)
+    integer(c_int32_t) :: PaleGreen = int(Z'98fb98', kind=c_int32_t)
+    integer(c_int32_t) :: SpringGreen = int(Z'00ff7f', kind=c_int32_t)
+    integer(c_int32_t) :: LawnGreen = int(Z'7cfc00', kind=c_int32_t)
+    integer(c_int32_t) :: Green = int(Z'00ff00', kind=c_int32_t)
+    integer(c_int32_t) :: Lime = int(Z'00ff00', kind=c_int32_t)
+    integer(c_int32_t) :: X11Green = int(Z'00ff00', kind=c_int32_t)
+    integer(c_int32_t) :: WebGreen = int(Z'008000', kind=c_int32_t)
+    integer(c_int32_t) :: Chartreuse = int(Z'7fff00', kind=c_int32_t)
+    integer(c_int32_t) :: MediumSpringGreen = int(Z'00fa9a', kind=c_int32_t)
+    integer(c_int32_t) :: GreenYellow = int(Z'adff2f', kind=c_int32_t)
+    integer(c_int32_t) :: LimeGreen = int(Z'32cd32', kind=c_int32_t)
+    integer(c_int32_t) :: YellowGreen = int(Z'9acd32', kind=c_int32_t)
+    integer(c_int32_t) :: ForestGreen = int(Z'228b22', kind=c_int32_t)
+    integer(c_int32_t) :: OliveDrab = int(Z'6b8e23', kind=c_int32_t)
+    integer(c_int32_t) :: DarkKhaki = int(Z'bdb76b', kind=c_int32_t)
+    integer(c_int32_t) :: Khaki = int(Z'f0e68c', kind=c_int32_t)
+    integer(c_int32_t) :: PaleGoldenrod = int(Z'eee8aa', kind=c_int32_t)
+    integer(c_int32_t) :: LightGoldenrodYellow = int(Z'fafad2', kind=c_int32_t)
+    integer(c_int32_t) :: LightYellow = int(Z'ffffe0', kind=c_int32_t)
+    integer(c_int32_t) :: Yellow = int(Z'ffff00', kind=c_int32_t)
+    integer(c_int32_t) :: Gold = int(Z'ffd700', kind=c_int32_t)
+    integer(c_int32_t) :: LightGoldenrod = int(Z'eedd82', kind=c_int32_t)
+    integer(c_int32_t) :: Goldenrod = int(Z'daa520', kind=c_int32_t)
+    integer(c_int32_t) :: DarkGoldenrod = int(Z'b8860b', kind=c_int32_t)
+    integer(c_int32_t) :: RosyBrown = int(Z'bc8f8f', kind=c_int32_t)
+    integer(c_int32_t) :: IndianRed = int(Z'cd5c5c', kind=c_int32_t)
+    integer(c_int32_t) :: SaddleBrown = int(Z'8b4513', kind=c_int32_t)
+    integer(c_int32_t) :: Sienna = int(Z'a0522d', kind=c_int32_t)
+    integer(c_int32_t) :: Peru = int(Z'cd853f', kind=c_int32_t)
+    integer(c_int32_t) :: Burlywood = int(Z'deb887', kind=c_int32_t)
+    integer(c_int32_t) :: Beige = int(Z'f5f5dc', kind=c_int32_t)
+    integer(c_int32_t) :: Wheat = int(Z'f5deb3', kind=c_int32_t)
+    integer(c_int32_t) :: SandyBrown = int(Z'f4a460', kind=c_int32_t)
+    integer(c_int32_t) :: Tan = int(Z'd2b48c', kind=c_int32_t)
+    integer(c_int32_t) :: Chocolate = int(Z'd2691e', kind=c_int32_t)
+    integer(c_int32_t) :: Firebrick = int(Z'b22222', kind=c_int32_t)
+    integer(c_int32_t) :: Brown = int(Z'a52a2a', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSalmon = int(Z'e9967a', kind=c_int32_t)
+    integer(c_int32_t) :: Salmon = int(Z'fa8072', kind=c_int32_t)
+    integer(c_int32_t) :: LightSalmon = int(Z'ffa07a', kind=c_int32_t)
+    integer(c_int32_t) :: Orange = int(Z'ffa500', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrange = int(Z'ff8c00', kind=c_int32_t)
+    integer(c_int32_t) :: Coral = int(Z'ff7f50', kind=c_int32_t)
+    integer(c_int32_t) :: LightCoral = int(Z'f08080', kind=c_int32_t)
+    integer(c_int32_t) :: Tomato = int(Z'ff6347', kind=c_int32_t)
+    integer(c_int32_t) :: OrangeRed = int(Z'ff4500', kind=c_int32_t)
+    integer(c_int32_t) :: Red = int(Z'ff0000', kind=c_int32_t)
+    integer(c_int32_t) :: HotPink = int(Z'ff69b4', kind=c_int32_t)
+    integer(c_int32_t) :: DeepPink = int(Z'ff1493', kind=c_int32_t)
+    integer(c_int32_t) :: Pink = int(Z'ffc0cb', kind=c_int32_t)
+    integer(c_int32_t) :: LightPink = int(Z'ffb6c1', kind=c_int32_t)
+    integer(c_int32_t) :: PaleVioletRed = int(Z'db7093', kind=c_int32_t)
+    integer(c_int32_t) :: Maroon = int(Z'b03060', kind=c_int32_t)
+    integer(c_int32_t) :: X11Maroon = int(Z'b03060', kind=c_int32_t)
+    integer(c_int32_t) :: WebMaroon = int(Z'800000', kind=c_int32_t)
+    integer(c_int32_t) :: MediumVioletRed = int(Z'c71585', kind=c_int32_t)
+    integer(c_int32_t) :: VioletRed = int(Z'd02090', kind=c_int32_t)
+    integer(c_int32_t) :: Magenta = int(Z'ff00ff', kind=c_int32_t)
+    integer(c_int32_t) :: Fuchsia = int(Z'ff00ff', kind=c_int32_t)
+    integer(c_int32_t) :: Violet = int(Z'ee82ee', kind=c_int32_t)
+    integer(c_int32_t) :: Plum = int(Z'dda0dd', kind=c_int32_t)
+    integer(c_int32_t) :: Orchid = int(Z'da70d6', kind=c_int32_t)
+    integer(c_int32_t) :: MediumOrchid = int(Z'ba55d3', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrchid = int(Z'9932cc', kind=c_int32_t)
+    integer(c_int32_t) :: DarkViolet = int(Z'9400d3', kind=c_int32_t)
+    integer(c_int32_t) :: BlueViolet = int(Z'8a2be2', kind=c_int32_t)
+    integer(c_int32_t) :: Purple = int(Z'a020f0', kind=c_int32_t)
+    integer(c_int32_t) :: X11Purple = int(Z'a020f0', kind=c_int32_t)
+    integer(c_int32_t) :: WebPurple = int(Z'800080', kind=c_int32_t)
+    integer(c_int32_t) :: MediumPurple = int(Z'9370db', kind=c_int32_t)
+    integer(c_int32_t) :: Thistle = int(Z'd8bfd8', kind=c_int32_t)
+    integer(c_int32_t) :: Snow1 = int(Z'fffafa', kind=c_int32_t)
+    integer(c_int32_t) :: Snow2 = int(Z'eee9e9', kind=c_int32_t)
+    integer(c_int32_t) :: Snow3 = int(Z'cdc9c9', kind=c_int32_t)
+    integer(c_int32_t) :: Snow4 = int(Z'8b8989', kind=c_int32_t)
+    integer(c_int32_t) :: Seashell1 = int(Z'fff5ee', kind=c_int32_t)
+    integer(c_int32_t) :: Seashell2 = int(Z'eee5de', kind=c_int32_t)
+    integer(c_int32_t) :: Seashell3 = int(Z'cdc5bf', kind=c_int32_t)
+    integer(c_int32_t) :: Seashell4 = int(Z'8b8682', kind=c_int32_t)
+    integer(c_int32_t) :: AntiqueWhite1 = int(Z'ffefdb', kind=c_int32_t)
+    integer(c_int32_t) :: AntiqueWhite2 = int(Z'eedfcc', kind=c_int32_t)
+    integer(c_int32_t) :: AntiqueWhite3 = int(Z'cdc0b0', kind=c_int32_t)
+    integer(c_int32_t) :: AntiqueWhite4 = int(Z'8b8378', kind=c_int32_t)
+    integer(c_int32_t) :: Bisque1 = int(Z'ffe4c4', kind=c_int32_t)
+    integer(c_int32_t) :: Bisque2 = int(Z'eed5b7', kind=c_int32_t)
+    integer(c_int32_t) :: Bisque3 = int(Z'cdb79e', kind=c_int32_t)
+    integer(c_int32_t) :: Bisque4 = int(Z'8b7d6b', kind=c_int32_t)
+    integer(c_int32_t) :: PeachPuff1 = int(Z'ffdab9', kind=c_int32_t)
+    integer(c_int32_t) :: PeachPuff2 = int(Z'eecbad', kind=c_int32_t)
+    integer(c_int32_t) :: PeachPuff3 = int(Z'cdaf95', kind=c_int32_t)
+    integer(c_int32_t) :: PeachPuff4 = int(Z'8b7765', kind=c_int32_t)
+    integer(c_int32_t) :: NavajoWhite1 = int(Z'ffdead', kind=c_int32_t)
+    integer(c_int32_t) :: NavajoWhite2 = int(Z'eecfa1', kind=c_int32_t)
+    integer(c_int32_t) :: NavajoWhite3 = int(Z'cdb38b', kind=c_int32_t)
+    integer(c_int32_t) :: NavajoWhite4 = int(Z'8b795e', kind=c_int32_t)
+    integer(c_int32_t) :: LemonChiffon1 = int(Z'fffacd', kind=c_int32_t)
+    integer(c_int32_t) :: LemonChiffon2 = int(Z'eee9bf', kind=c_int32_t)
+    integer(c_int32_t) :: LemonChiffon3 = int(Z'cdc9a5', kind=c_int32_t)
+    integer(c_int32_t) :: LemonChiffon4 = int(Z'8b8970', kind=c_int32_t)
+    integer(c_int32_t) :: Cornsilk1 = int(Z'fff8dc', kind=c_int32_t)
+    integer(c_int32_t) :: Cornsilk2 = int(Z'eee8cd', kind=c_int32_t)
+    integer(c_int32_t) :: Cornsilk3 = int(Z'cdc8b1', kind=c_int32_t)
+    integer(c_int32_t) :: Cornsilk4 = int(Z'8b8878', kind=c_int32_t)
+    integer(c_int32_t) :: Ivory1 = int(Z'fffff0', kind=c_int32_t)
+    integer(c_int32_t) :: Ivory2 = int(Z'eeeee0', kind=c_int32_t)
+    integer(c_int32_t) :: Ivory3 = int(Z'cdcdc1', kind=c_int32_t)
+    integer(c_int32_t) :: Ivory4 = int(Z'8b8b83', kind=c_int32_t)
+    integer(c_int32_t) :: Honeydew1 = int(Z'f0fff0', kind=c_int32_t)
+    integer(c_int32_t) :: Honeydew2 = int(Z'e0eee0', kind=c_int32_t)
+    integer(c_int32_t) :: Honeydew3 = int(Z'c1cdc1', kind=c_int32_t)
+    integer(c_int32_t) :: Honeydew4 = int(Z'838b83', kind=c_int32_t)
+    integer(c_int32_t) :: LavenderBlush1 = int(Z'fff0f5', kind=c_int32_t)
+    integer(c_int32_t) :: LavenderBlush2 = int(Z'eee0e5', kind=c_int32_t)
+    integer(c_int32_t) :: LavenderBlush3 = int(Z'cdc1c5', kind=c_int32_t)
+    integer(c_int32_t) :: LavenderBlush4 = int(Z'8b8386', kind=c_int32_t)
+    integer(c_int32_t) :: MistyRose1 = int(Z'ffe4e1', kind=c_int32_t)
+    integer(c_int32_t) :: MistyRose2 = int(Z'eed5d2', kind=c_int32_t)
+    integer(c_int32_t) :: MistyRose3 = int(Z'cdb7b5', kind=c_int32_t)
+    integer(c_int32_t) :: MistyRose4 = int(Z'8b7d7b', kind=c_int32_t)
+    integer(c_int32_t) :: Azure1 = int(Z'f0ffff', kind=c_int32_t)
+    integer(c_int32_t) :: Azure2 = int(Z'e0eeee', kind=c_int32_t)
+    integer(c_int32_t) :: Azure3 = int(Z'c1cdcd', kind=c_int32_t)
+    integer(c_int32_t) :: Azure4 = int(Z'838b8b', kind=c_int32_t)
+    integer(c_int32_t) :: SlateBlue1 = int(Z'836fff', kind=c_int32_t)
+    integer(c_int32_t) :: SlateBlue2 = int(Z'7a67ee', kind=c_int32_t)
+    integer(c_int32_t) :: SlateBlue3 = int(Z'6959cd', kind=c_int32_t)
+    integer(c_int32_t) :: SlateBlue4 = int(Z'473c8b', kind=c_int32_t)
+    integer(c_int32_t) :: RoyalBlue1 = int(Z'4876ff', kind=c_int32_t)
+    integer(c_int32_t) :: RoyalBlue2 = int(Z'436eee', kind=c_int32_t)
+    integer(c_int32_t) :: RoyalBlue3 = int(Z'3a5fcd', kind=c_int32_t)
+    integer(c_int32_t) :: RoyalBlue4 = int(Z'27408b', kind=c_int32_t)
+    integer(c_int32_t) :: Blue1 = int(Z'0000ff', kind=c_int32_t)
+    integer(c_int32_t) :: Blue2 = int(Z'0000ee', kind=c_int32_t)
+    integer(c_int32_t) :: Blue3 = int(Z'0000cd', kind=c_int32_t)
+    integer(c_int32_t) :: Blue4 = int(Z'00008b', kind=c_int32_t)
+    integer(c_int32_t) :: DodgerBlue1 = int(Z'1e90ff', kind=c_int32_t)
+    integer(c_int32_t) :: DodgerBlue2 = int(Z'1c86ee', kind=c_int32_t)
+    integer(c_int32_t) :: DodgerBlue3 = int(Z'1874cd', kind=c_int32_t)
+    integer(c_int32_t) :: DodgerBlue4 = int(Z'104e8b', kind=c_int32_t)
+    integer(c_int32_t) :: SteelBlue1 = int(Z'63b8ff', kind=c_int32_t)
+    integer(c_int32_t) :: SteelBlue2 = int(Z'5cacee', kind=c_int32_t)
+    integer(c_int32_t) :: SteelBlue3 = int(Z'4f94cd', kind=c_int32_t)
+    integer(c_int32_t) :: SteelBlue4 = int(Z'36648b', kind=c_int32_t)
+    integer(c_int32_t) :: DeepSkyBlue1 = int(Z'00bfff', kind=c_int32_t)
+    integer(c_int32_t) :: DeepSkyBlue2 = int(Z'00b2ee', kind=c_int32_t)
+    integer(c_int32_t) :: DeepSkyBlue3 = int(Z'009acd', kind=c_int32_t)
+    integer(c_int32_t) :: DeepSkyBlue4 = int(Z'00688b', kind=c_int32_t)
+    integer(c_int32_t) :: SkyBlue1 = int(Z'87ceff', kind=c_int32_t)
+    integer(c_int32_t) :: SkyBlue2 = int(Z'7ec0ee', kind=c_int32_t)
+    integer(c_int32_t) :: SkyBlue3 = int(Z'6ca6cd', kind=c_int32_t)
+    integer(c_int32_t) :: SkyBlue4 = int(Z'4a708b', kind=c_int32_t)
+    integer(c_int32_t) :: LightSkyBlue1 = int(Z'b0e2ff', kind=c_int32_t)
+    integer(c_int32_t) :: LightSkyBlue2 = int(Z'a4d3ee', kind=c_int32_t)
+    integer(c_int32_t) :: LightSkyBlue3 = int(Z'8db6cd', kind=c_int32_t)
+    integer(c_int32_t) :: LightSkyBlue4 = int(Z'607b8b', kind=c_int32_t)
+    integer(c_int32_t) :: SlateGray1 = int(Z'c6e2ff', kind=c_int32_t)
+    integer(c_int32_t) :: SlateGray2 = int(Z'b9d3ee', kind=c_int32_t)
+    integer(c_int32_t) :: SlateGray3 = int(Z'9fb6cd', kind=c_int32_t)
+    integer(c_int32_t) :: SlateGray4 = int(Z'6c7b8b', kind=c_int32_t)
+    integer(c_int32_t) :: LightSteelBlue1 = int(Z'cae1ff', kind=c_int32_t)
+    integer(c_int32_t) :: LightSteelBlue2 = int(Z'bcd2ee', kind=c_int32_t)
+    integer(c_int32_t) :: LightSteelBlue3 = int(Z'a2b5cd', kind=c_int32_t)
+    integer(c_int32_t) :: LightSteelBlue4 = int(Z'6e7b8b', kind=c_int32_t)
+    integer(c_int32_t) :: LightBlue1 = int(Z'bfefff', kind=c_int32_t)
+    integer(c_int32_t) :: LightBlue2 = int(Z'b2dfee', kind=c_int32_t)
+    integer(c_int32_t) :: LightBlue3 = int(Z'9ac0cd', kind=c_int32_t)
+    integer(c_int32_t) :: LightBlue4 = int(Z'68838b', kind=c_int32_t)
+    integer(c_int32_t) :: LightCyan1 = int(Z'e0ffff', kind=c_int32_t)
+    integer(c_int32_t) :: LightCyan2 = int(Z'd1eeee', kind=c_int32_t)
+    integer(c_int32_t) :: LightCyan3 = int(Z'b4cdcd', kind=c_int32_t)
+    integer(c_int32_t) :: LightCyan4 = int(Z'7a8b8b', kind=c_int32_t)
+    integer(c_int32_t) :: PaleTurquoise1 = int(Z'bbffff', kind=c_int32_t)
+    integer(c_int32_t) :: PaleTurquoise2 = int(Z'aeeeee', kind=c_int32_t)
+    integer(c_int32_t) :: PaleTurquoise3 = int(Z'96cdcd', kind=c_int32_t)
+    integer(c_int32_t) :: PaleTurquoise4 = int(Z'668b8b', kind=c_int32_t)
+    integer(c_int32_t) :: CadetBlue1 = int(Z'98f5ff', kind=c_int32_t)
+    integer(c_int32_t) :: CadetBlue2 = int(Z'8ee5ee', kind=c_int32_t)
+    integer(c_int32_t) :: CadetBlue3 = int(Z'7ac5cd', kind=c_int32_t)
+    integer(c_int32_t) :: CadetBlue4 = int(Z'53868b', kind=c_int32_t)
+    integer(c_int32_t) :: Turquoise1 = int(Z'00f5ff', kind=c_int32_t)
+    integer(c_int32_t) :: Turquoise2 = int(Z'00e5ee', kind=c_int32_t)
+    integer(c_int32_t) :: Turquoise3 = int(Z'00c5cd', kind=c_int32_t)
+    integer(c_int32_t) :: Turquoise4 = int(Z'00868b', kind=c_int32_t)
+    integer(c_int32_t) :: Cyan1 = int(Z'00ffff', kind=c_int32_t)
+    integer(c_int32_t) :: Cyan2 = int(Z'00eeee', kind=c_int32_t)
+    integer(c_int32_t) :: Cyan3 = int(Z'00cdcd', kind=c_int32_t)
+    integer(c_int32_t) :: Cyan4 = int(Z'008b8b', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSlateGray1 = int(Z'97ffff', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSlateGray2 = int(Z'8deeee', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSlateGray3 = int(Z'79cdcd', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSlateGray4 = int(Z'528b8b', kind=c_int32_t)
+    integer(c_int32_t) :: Aquamarine1 = int(Z'7fffd4', kind=c_int32_t)
+    integer(c_int32_t) :: Aquamarine2 = int(Z'76eec6', kind=c_int32_t)
+    integer(c_int32_t) :: Aquamarine3 = int(Z'66cdaa', kind=c_int32_t)
+    integer(c_int32_t) :: Aquamarine4 = int(Z'458b74', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSeaGreen1 = int(Z'c1ffc1', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSeaGreen2 = int(Z'b4eeb4', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSeaGreen3 = int(Z'9bcd9b', kind=c_int32_t)
+    integer(c_int32_t) :: DarkSeaGreen4 = int(Z'698b69', kind=c_int32_t)
+    integer(c_int32_t) :: SeaGreen1 = int(Z'54ff9f', kind=c_int32_t)
+    integer(c_int32_t) :: SeaGreen2 = int(Z'4eee94', kind=c_int32_t)
+    integer(c_int32_t) :: SeaGreen3 = int(Z'43cd80', kind=c_int32_t)
+    integer(c_int32_t) :: SeaGreen4 = int(Z'2e8b57', kind=c_int32_t)
+    integer(c_int32_t) :: PaleGreen1 = int(Z'9aff9a', kind=c_int32_t)
+    integer(c_int32_t) :: PaleGreen2 = int(Z'90ee90', kind=c_int32_t)
+    integer(c_int32_t) :: PaleGreen3 = int(Z'7ccd7c', kind=c_int32_t)
+    integer(c_int32_t) :: PaleGreen4 = int(Z'548b54', kind=c_int32_t)
+    integer(c_int32_t) :: SpringGreen1 = int(Z'00ff7f', kind=c_int32_t)
+    integer(c_int32_t) :: SpringGreen2 = int(Z'00ee76', kind=c_int32_t)
+    integer(c_int32_t) :: SpringGreen3 = int(Z'00cd66', kind=c_int32_t)
+    integer(c_int32_t) :: SpringGreen4 = int(Z'008b45', kind=c_int32_t)
+    integer(c_int32_t) :: Green1 = int(Z'00ff00', kind=c_int32_t)
+    integer(c_int32_t) :: Green2 = int(Z'00ee00', kind=c_int32_t)
+    integer(c_int32_t) :: Green3 = int(Z'00cd00', kind=c_int32_t)
+    integer(c_int32_t) :: Green4 = int(Z'008b00', kind=c_int32_t)
+    integer(c_int32_t) :: Chartreuse1 = int(Z'7fff00', kind=c_int32_t)
+    integer(c_int32_t) :: Chartreuse2 = int(Z'76ee00', kind=c_int32_t)
+    integer(c_int32_t) :: Chartreuse3 = int(Z'66cd00', kind=c_int32_t)
+    integer(c_int32_t) :: Chartreuse4 = int(Z'458b00', kind=c_int32_t)
+    integer(c_int32_t) :: OliveDrab1 = int(Z'c0ff3e', kind=c_int32_t)
+    integer(c_int32_t) :: OliveDrab2 = int(Z'b3ee3a', kind=c_int32_t)
+    integer(c_int32_t) :: OliveDrab3 = int(Z'9acd32', kind=c_int32_t)
+    integer(c_int32_t) :: OliveDrab4 = int(Z'698b22', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOliveGreen1 = int(Z'caff70', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOliveGreen2 = int(Z'bcee68', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOliveGreen3 = int(Z'a2cd5a', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOliveGreen4 = int(Z'6e8b3d', kind=c_int32_t)
+    integer(c_int32_t) :: Khaki1 = int(Z'fff68f', kind=c_int32_t)
+    integer(c_int32_t) :: Khaki2 = int(Z'eee685', kind=c_int32_t)
+    integer(c_int32_t) :: Khaki3 = int(Z'cdc673', kind=c_int32_t)
+    integer(c_int32_t) :: Khaki4 = int(Z'8b864e', kind=c_int32_t)
+    integer(c_int32_t) :: LightGoldenrod1 = int(Z'ffec8b', kind=c_int32_t)
+    integer(c_int32_t) :: LightGoldenrod2 = int(Z'eedc82', kind=c_int32_t)
+    integer(c_int32_t) :: LightGoldenrod3 = int(Z'cdbe70', kind=c_int32_t)
+    integer(c_int32_t) :: LightGoldenrod4 = int(Z'8b814c', kind=c_int32_t)
+    integer(c_int32_t) :: LightYellow1 = int(Z'ffffe0', kind=c_int32_t)
+    integer(c_int32_t) :: LightYellow2 = int(Z'eeeed1', kind=c_int32_t)
+    integer(c_int32_t) :: LightYellow3 = int(Z'cdcdb4', kind=c_int32_t)
+    integer(c_int32_t) :: LightYellow4 = int(Z'8b8b7a', kind=c_int32_t)
+    integer(c_int32_t) :: Yellow1 = int(Z'ffff00', kind=c_int32_t)
+    integer(c_int32_t) :: Yellow2 = int(Z'eeee00', kind=c_int32_t)
+    integer(c_int32_t) :: Yellow3 = int(Z'cdcd00', kind=c_int32_t)
+    integer(c_int32_t) :: Yellow4 = int(Z'8b8b00', kind=c_int32_t)
+    integer(c_int32_t) :: Gold1 = int(Z'ffd700', kind=c_int32_t)
+    integer(c_int32_t) :: Gold2 = int(Z'eec900', kind=c_int32_t)
+    integer(c_int32_t) :: Gold3 = int(Z'cdad00', kind=c_int32_t)
+    integer(c_int32_t) :: Gold4 = int(Z'8b7500', kind=c_int32_t)
+    integer(c_int32_t) :: Goldenrod1 = int(Z'ffc125', kind=c_int32_t)
+    integer(c_int32_t) :: Goldenrod2 = int(Z'eeb422', kind=c_int32_t)
+    integer(c_int32_t) :: Goldenrod3 = int(Z'cd9b1d', kind=c_int32_t)
+    integer(c_int32_t) :: Goldenrod4 = int(Z'8b6914', kind=c_int32_t)
+    integer(c_int32_t) :: DarkGoldenrod1 = int(Z'ffb90f', kind=c_int32_t)
+    integer(c_int32_t) :: DarkGoldenrod2 = int(Z'eead0e', kind=c_int32_t)
+    integer(c_int32_t) :: DarkGoldenrod3 = int(Z'cd950c', kind=c_int32_t)
+    integer(c_int32_t) :: DarkGoldenrod4 = int(Z'8b6508', kind=c_int32_t)
+    integer(c_int32_t) :: RosyBrown1 = int(Z'ffc1c1', kind=c_int32_t)
+    integer(c_int32_t) :: RosyBrown2 = int(Z'eeb4b4', kind=c_int32_t)
+    integer(c_int32_t) :: RosyBrown3 = int(Z'cd9b9b', kind=c_int32_t)
+    integer(c_int32_t) :: RosyBrown4 = int(Z'8b6969', kind=c_int32_t)
+    integer(c_int32_t) :: IndianRed1 = int(Z'ff6a6a', kind=c_int32_t)
+    integer(c_int32_t) :: IndianRed2 = int(Z'ee6363', kind=c_int32_t)
+    integer(c_int32_t) :: IndianRed3 = int(Z'cd5555', kind=c_int32_t)
+    integer(c_int32_t) :: IndianRed4 = int(Z'8b3a3a', kind=c_int32_t)
+    integer(c_int32_t) :: Sienna1 = int(Z'ff8247', kind=c_int32_t)
+    integer(c_int32_t) :: Sienna2 = int(Z'ee7942', kind=c_int32_t)
+    integer(c_int32_t) :: Sienna3 = int(Z'cd6839', kind=c_int32_t)
+    integer(c_int32_t) :: Sienna4 = int(Z'8b4726', kind=c_int32_t)
+    integer(c_int32_t) :: Burlywood1 = int(Z'ffd39b', kind=c_int32_t)
+    integer(c_int32_t) :: Burlywood2 = int(Z'eec591', kind=c_int32_t)
+    integer(c_int32_t) :: Burlywood3 = int(Z'cdaa7d', kind=c_int32_t)
+    integer(c_int32_t) :: Burlywood4 = int(Z'8b7355', kind=c_int32_t)
+    integer(c_int32_t) :: Wheat1 = int(Z'ffe7ba', kind=c_int32_t)
+    integer(c_int32_t) :: Wheat2 = int(Z'eed8ae', kind=c_int32_t)
+    integer(c_int32_t) :: Wheat3 = int(Z'cdba96', kind=c_int32_t)
+    integer(c_int32_t) :: Wheat4 = int(Z'8b7e66', kind=c_int32_t)
+    integer(c_int32_t) :: Tan1 = int(Z'ffa54f', kind=c_int32_t)
+    integer(c_int32_t) :: Tan2 = int(Z'ee9a49', kind=c_int32_t)
+    integer(c_int32_t) :: Tan3 = int(Z'cd853f', kind=c_int32_t)
+    integer(c_int32_t) :: Tan4 = int(Z'8b5a2b', kind=c_int32_t)
+    integer(c_int32_t) :: Chocolate1 = int(Z'ff7f24', kind=c_int32_t)
+    integer(c_int32_t) :: Chocolate2 = int(Z'ee7621', kind=c_int32_t)
+    integer(c_int32_t) :: Chocolate3 = int(Z'cd661d', kind=c_int32_t)
+    integer(c_int32_t) :: Chocolate4 = int(Z'8b4513', kind=c_int32_t)
+    integer(c_int32_t) :: Firebrick1 = int(Z'ff3030', kind=c_int32_t)
+    integer(c_int32_t) :: Firebrick2 = int(Z'ee2c2c', kind=c_int32_t)
+    integer(c_int32_t) :: Firebrick3 = int(Z'cd2626', kind=c_int32_t)
+    integer(c_int32_t) :: Firebrick4 = int(Z'8b1a1a', kind=c_int32_t)
+    integer(c_int32_t) :: Brown1 = int(Z'ff4040', kind=c_int32_t)
+    integer(c_int32_t) :: Brown2 = int(Z'ee3b3b', kind=c_int32_t)
+    integer(c_int32_t) :: Brown3 = int(Z'cd3333', kind=c_int32_t)
+    integer(c_int32_t) :: Brown4 = int(Z'8b2323', kind=c_int32_t)
+    integer(c_int32_t) :: Salmon1 = int(Z'ff8c69', kind=c_int32_t)
+    integer(c_int32_t) :: Salmon2 = int(Z'ee8262', kind=c_int32_t)
+    integer(c_int32_t) :: Salmon3 = int(Z'cd7054', kind=c_int32_t)
+    integer(c_int32_t) :: Salmon4 = int(Z'8b4c39', kind=c_int32_t)
+    integer(c_int32_t) :: LightSalmon1 = int(Z'ffa07a', kind=c_int32_t)
+    integer(c_int32_t) :: LightSalmon2 = int(Z'ee9572', kind=c_int32_t)
+    integer(c_int32_t) :: LightSalmon3 = int(Z'cd8162', kind=c_int32_t)
+    integer(c_int32_t) :: LightSalmon4 = int(Z'8b5742', kind=c_int32_t)
+    integer(c_int32_t) :: Orange1 = int(Z'ffa500', kind=c_int32_t)
+    integer(c_int32_t) :: Orange2 = int(Z'ee9a00', kind=c_int32_t)
+    integer(c_int32_t) :: Orange3 = int(Z'cd8500', kind=c_int32_t)
+    integer(c_int32_t) :: Orange4 = int(Z'8b5a00', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrange1 = int(Z'ff7f00', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrange2 = int(Z'ee7600', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrange3 = int(Z'cd6600', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrange4 = int(Z'8b4500', kind=c_int32_t)
+    integer(c_int32_t) :: Coral1 = int(Z'ff7256', kind=c_int32_t)
+    integer(c_int32_t) :: Coral2 = int(Z'ee6a50', kind=c_int32_t)
+    integer(c_int32_t) :: Coral3 = int(Z'cd5b45', kind=c_int32_t)
+    integer(c_int32_t) :: Coral4 = int(Z'8b3e2f', kind=c_int32_t)
+    integer(c_int32_t) :: Tomato1 = int(Z'ff6347', kind=c_int32_t)
+    integer(c_int32_t) :: Tomato2 = int(Z'ee5c42', kind=c_int32_t)
+    integer(c_int32_t) :: Tomato3 = int(Z'cd4f39', kind=c_int32_t)
+    integer(c_int32_t) :: Tomato4 = int(Z'8b3626', kind=c_int32_t)
+    integer(c_int32_t) :: OrangeRed1 = int(Z'ff4500', kind=c_int32_t)
+    integer(c_int32_t) :: OrangeRed2 = int(Z'ee4000', kind=c_int32_t)
+    integer(c_int32_t) :: OrangeRed3 = int(Z'cd3700', kind=c_int32_t)
+    integer(c_int32_t) :: OrangeRed4 = int(Z'8b2500', kind=c_int32_t)
+    integer(c_int32_t) :: Red1 = int(Z'ff0000', kind=c_int32_t)
+    integer(c_int32_t) :: Red2 = int(Z'ee0000', kind=c_int32_t)
+    integer(c_int32_t) :: Red3 = int(Z'cd0000', kind=c_int32_t)
+    integer(c_int32_t) :: Red4 = int(Z'8b0000', kind=c_int32_t)
+    integer(c_int32_t) :: DeepPink1 = int(Z'ff1493', kind=c_int32_t)
+    integer(c_int32_t) :: DeepPink2 = int(Z'ee1289', kind=c_int32_t)
+    integer(c_int32_t) :: DeepPink3 = int(Z'cd1076', kind=c_int32_t)
+    integer(c_int32_t) :: DeepPink4 = int(Z'8b0a50', kind=c_int32_t)
+    integer(c_int32_t) :: HotPink1 = int(Z'ff6eb4', kind=c_int32_t)
+    integer(c_int32_t) :: HotPink2 = int(Z'ee6aa7', kind=c_int32_t)
+    integer(c_int32_t) :: HotPink3 = int(Z'cd6090', kind=c_int32_t)
+    integer(c_int32_t) :: HotPink4 = int(Z'8b3a62', kind=c_int32_t)
+    integer(c_int32_t) :: Pink1 = int(Z'ffb5c5', kind=c_int32_t)
+    integer(c_int32_t) :: Pink2 = int(Z'eea9b8', kind=c_int32_t)
+    integer(c_int32_t) :: Pink3 = int(Z'cd919e', kind=c_int32_t)
+    integer(c_int32_t) :: Pink4 = int(Z'8b636c', kind=c_int32_t)
+    integer(c_int32_t) :: LightPink1 = int(Z'ffaeb9', kind=c_int32_t)
+    integer(c_int32_t) :: LightPink2 = int(Z'eea2ad', kind=c_int32_t)
+    integer(c_int32_t) :: LightPink3 = int(Z'cd8c95', kind=c_int32_t)
+    integer(c_int32_t) :: LightPink4 = int(Z'8b5f65', kind=c_int32_t)
+    integer(c_int32_t) :: PaleVioletRed1 = int(Z'ff82ab', kind=c_int32_t)
+    integer(c_int32_t) :: PaleVioletRed2 = int(Z'ee799f', kind=c_int32_t)
+    integer(c_int32_t) :: PaleVioletRed3 = int(Z'cd6889', kind=c_int32_t)
+    integer(c_int32_t) :: PaleVioletRed4 = int(Z'8b475d', kind=c_int32_t)
+    integer(c_int32_t) :: Maroon1 = int(Z'ff34b3', kind=c_int32_t)
+    integer(c_int32_t) :: Maroon2 = int(Z'ee30a7', kind=c_int32_t)
+    integer(c_int32_t) :: Maroon3 = int(Z'cd2990', kind=c_int32_t)
+    integer(c_int32_t) :: Maroon4 = int(Z'8b1c62', kind=c_int32_t)
+    integer(c_int32_t) :: VioletRed1 = int(Z'ff3e96', kind=c_int32_t)
+    integer(c_int32_t) :: VioletRed2 = int(Z'ee3a8c', kind=c_int32_t)
+    integer(c_int32_t) :: VioletRed3 = int(Z'cd3278', kind=c_int32_t)
+    integer(c_int32_t) :: VioletRed4 = int(Z'8b2252', kind=c_int32_t)
+    integer(c_int32_t) :: Magenta1 = int(Z'ff00ff', kind=c_int32_t)
+    integer(c_int32_t) :: Magenta2 = int(Z'ee00ee', kind=c_int32_t)
+    integer(c_int32_t) :: Magenta3 = int(Z'cd00cd', kind=c_int32_t)
+    integer(c_int32_t) :: Magenta4 = int(Z'8b008b', kind=c_int32_t)
+    integer(c_int32_t) :: Orchid1 = int(Z'ff83fa', kind=c_int32_t)
+    integer(c_int32_t) :: Orchid2 = int(Z'ee7ae9', kind=c_int32_t)
+    integer(c_int32_t) :: Orchid3 = int(Z'cd69c9', kind=c_int32_t)
+    integer(c_int32_t) :: Orchid4 = int(Z'8b4789', kind=c_int32_t)
+    integer(c_int32_t) :: Plum1 = int(Z'ffbbff', kind=c_int32_t)
+    integer(c_int32_t) :: Plum2 = int(Z'eeaeee', kind=c_int32_t)
+    integer(c_int32_t) :: Plum3 = int(Z'cd96cd', kind=c_int32_t)
+    integer(c_int32_t) :: Plum4 = int(Z'8b668b', kind=c_int32_t)
+    integer(c_int32_t) :: MediumOrchid1 = int(Z'e066ff', kind=c_int32_t)
+    integer(c_int32_t) :: MediumOrchid2 = int(Z'd15fee', kind=c_int32_t)
+    integer(c_int32_t) :: MediumOrchid3 = int(Z'b452cd', kind=c_int32_t)
+    integer(c_int32_t) :: MediumOrchid4 = int(Z'7a378b', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrchid1 = int(Z'bf3eff', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrchid2 = int(Z'b23aee', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrchid3 = int(Z'9a32cd', kind=c_int32_t)
+    integer(c_int32_t) :: DarkOrchid4 = int(Z'68228b', kind=c_int32_t)
+    integer(c_int32_t) :: Purple1 = int(Z'9b30ff', kind=c_int32_t)
+    integer(c_int32_t) :: Purple2 = int(Z'912cee', kind=c_int32_t)
+    integer(c_int32_t) :: Purple3 = int(Z'7d26cd', kind=c_int32_t)
+    integer(c_int32_t) :: Purple4 = int(Z'551a8b', kind=c_int32_t)
+    integer(c_int32_t) :: MediumPurple1 = int(Z'ab82ff', kind=c_int32_t)
+    integer(c_int32_t) :: MediumPurple2 = int(Z'9f79ee', kind=c_int32_t)
+    integer(c_int32_t) :: MediumPurple3 = int(Z'8968cd', kind=c_int32_t)
+    integer(c_int32_t) :: MediumPurple4 = int(Z'5d478b', kind=c_int32_t)
+    integer(c_int32_t) :: Thistle1 = int(Z'ffe1ff', kind=c_int32_t)
+    integer(c_int32_t) :: Thistle2 = int(Z'eed2ee', kind=c_int32_t)
+    integer(c_int32_t) :: Thistle3 = int(Z'cdb5cd', kind=c_int32_t)
+    integer(c_int32_t) :: Thistle4 = int(Z'8b7b8b', kind=c_int32_t)
+    integer(c_int32_t) :: Gray0 = int(Z'000000', kind=c_int32_t)
+    integer(c_int32_t) :: Grey0 = int(Z'000000', kind=c_int32_t)
+    integer(c_int32_t) :: Gray1 = int(Z'030303', kind=c_int32_t)
+    integer(c_int32_t) :: Grey1 = int(Z'030303', kind=c_int32_t)
+    integer(c_int32_t) :: Gray2 = int(Z'050505', kind=c_int32_t)
+    integer(c_int32_t) :: Grey2 = int(Z'050505', kind=c_int32_t)
+    integer(c_int32_t) :: Gray3 = int(Z'080808', kind=c_int32_t)
+    integer(c_int32_t) :: Grey3 = int(Z'080808', kind=c_int32_t)
+    integer(c_int32_t) :: Gray4 = int(Z'0a0a0a', kind=c_int32_t)
+    integer(c_int32_t) :: Grey4 = int(Z'0a0a0a', kind=c_int32_t)
+    integer(c_int32_t) :: Gray5 = int(Z'0d0d0d', kind=c_int32_t)
+    integer(c_int32_t) :: Grey5 = int(Z'0d0d0d', kind=c_int32_t)
+    integer(c_int32_t) :: Gray6 = int(Z'0f0f0f', kind=c_int32_t)
+    integer(c_int32_t) :: Grey6 = int(Z'0f0f0f', kind=c_int32_t)
+    integer(c_int32_t) :: Gray7 = int(Z'121212', kind=c_int32_t)
+    integer(c_int32_t) :: Grey7 = int(Z'121212', kind=c_int32_t)
+    integer(c_int32_t) :: Gray8 = int(Z'141414', kind=c_int32_t)
+    integer(c_int32_t) :: Grey8 = int(Z'141414', kind=c_int32_t)
+    integer(c_int32_t) :: Gray9 = int(Z'171717', kind=c_int32_t)
+    integer(c_int32_t) :: Grey9 = int(Z'171717', kind=c_int32_t)
+    integer(c_int32_t) :: Gray10 = int(Z'1a1a1a', kind=c_int32_t)
+    integer(c_int32_t) :: Grey10 = int(Z'1a1a1a', kind=c_int32_t)
+    integer(c_int32_t) :: Gray11 = int(Z'1c1c1c', kind=c_int32_t)
+    integer(c_int32_t) :: Grey11 = int(Z'1c1c1c', kind=c_int32_t)
+    integer(c_int32_t) :: Gray12 = int(Z'1f1f1f', kind=c_int32_t)
+    integer(c_int32_t) :: Grey12 = int(Z'1f1f1f', kind=c_int32_t)
+    integer(c_int32_t) :: Gray13 = int(Z'212121', kind=c_int32_t)
+    integer(c_int32_t) :: Grey13 = int(Z'212121', kind=c_int32_t)
+    integer(c_int32_t) :: Gray14 = int(Z'242424', kind=c_int32_t)
+    integer(c_int32_t) :: Grey14 = int(Z'242424', kind=c_int32_t)
+    integer(c_int32_t) :: Gray15 = int(Z'262626', kind=c_int32_t)
+    integer(c_int32_t) :: Grey15 = int(Z'262626', kind=c_int32_t)
+    integer(c_int32_t) :: Gray16 = int(Z'292929', kind=c_int32_t)
+    integer(c_int32_t) :: Grey16 = int(Z'292929', kind=c_int32_t)
+    integer(c_int32_t) :: Gray17 = int(Z'2b2b2b', kind=c_int32_t)
+    integer(c_int32_t) :: Grey17 = int(Z'2b2b2b', kind=c_int32_t)
+    integer(c_int32_t) :: Gray18 = int(Z'2e2e2e', kind=c_int32_t)
+    integer(c_int32_t) :: Grey18 = int(Z'2e2e2e', kind=c_int32_t)
+    integer(c_int32_t) :: Gray19 = int(Z'303030', kind=c_int32_t)
+    integer(c_int32_t) :: Grey19 = int(Z'303030', kind=c_int32_t)
+    integer(c_int32_t) :: Gray20 = int(Z'333333', kind=c_int32_t)
+    integer(c_int32_t) :: Grey20 = int(Z'333333', kind=c_int32_t)
+    integer(c_int32_t) :: Gray21 = int(Z'363636', kind=c_int32_t)
+    integer(c_int32_t) :: Grey21 = int(Z'363636', kind=c_int32_t)
+    integer(c_int32_t) :: Gray22 = int(Z'383838', kind=c_int32_t)
+    integer(c_int32_t) :: Grey22 = int(Z'383838', kind=c_int32_t)
+    integer(c_int32_t) :: Gray23 = int(Z'3b3b3b', kind=c_int32_t)
+    integer(c_int32_t) :: Grey23 = int(Z'3b3b3b', kind=c_int32_t)
+    integer(c_int32_t) :: Gray24 = int(Z'3d3d3d', kind=c_int32_t)
+    integer(c_int32_t) :: Grey24 = int(Z'3d3d3d', kind=c_int32_t)
+    integer(c_int32_t) :: Gray25 = int(Z'404040', kind=c_int32_t)
+    integer(c_int32_t) :: Grey25 = int(Z'404040', kind=c_int32_t)
+    integer(c_int32_t) :: Gray26 = int(Z'424242', kind=c_int32_t)
+    integer(c_int32_t) :: Grey26 = int(Z'424242', kind=c_int32_t)
+    integer(c_int32_t) :: Gray27 = int(Z'454545', kind=c_int32_t)
+    integer(c_int32_t) :: Grey27 = int(Z'454545', kind=c_int32_t)
+    integer(c_int32_t) :: Gray28 = int(Z'474747', kind=c_int32_t)
+    integer(c_int32_t) :: Grey28 = int(Z'474747', kind=c_int32_t)
+    integer(c_int32_t) :: Gray29 = int(Z'4a4a4a', kind=c_int32_t)
+    integer(c_int32_t) :: Grey29 = int(Z'4a4a4a', kind=c_int32_t)
+    integer(c_int32_t) :: Gray30 = int(Z'4d4d4d', kind=c_int32_t)
+    integer(c_int32_t) :: Grey30 = int(Z'4d4d4d', kind=c_int32_t)
+    integer(c_int32_t) :: Gray31 = int(Z'4f4f4f', kind=c_int32_t)
+    integer(c_int32_t) :: Grey31 = int(Z'4f4f4f', kind=c_int32_t)
+    integer(c_int32_t) :: Gray32 = int(Z'525252', kind=c_int32_t)
+    integer(c_int32_t) :: Grey32 = int(Z'525252', kind=c_int32_t)
+    integer(c_int32_t) :: Gray33 = int(Z'545454', kind=c_int32_t)
+    integer(c_int32_t) :: Grey33 = int(Z'545454', kind=c_int32_t)
+    integer(c_int32_t) :: Gray34 = int(Z'575757', kind=c_int32_t)
+    integer(c_int32_t) :: Grey34 = int(Z'575757', kind=c_int32_t)
+    integer(c_int32_t) :: Gray35 = int(Z'595959', kind=c_int32_t)
+    integer(c_int32_t) :: Grey35 = int(Z'595959', kind=c_int32_t)
+    integer(c_int32_t) :: Gray36 = int(Z'5c5c5c', kind=c_int32_t)
+    integer(c_int32_t) :: Grey36 = int(Z'5c5c5c', kind=c_int32_t)
+    integer(c_int32_t) :: Gray37 = int(Z'5e5e5e', kind=c_int32_t)
+    integer(c_int32_t) :: Grey37 = int(Z'5e5e5e', kind=c_int32_t)
+    integer(c_int32_t) :: Gray38 = int(Z'616161', kind=c_int32_t)
+    integer(c_int32_t) :: Grey38 = int(Z'616161', kind=c_int32_t)
+    integer(c_int32_t) :: Gray39 = int(Z'636363', kind=c_int32_t)
+    integer(c_int32_t) :: Grey39 = int(Z'636363', kind=c_int32_t)
+    integer(c_int32_t) :: Gray40 = int(Z'666666', kind=c_int32_t)
+    integer(c_int32_t) :: Grey40 = int(Z'666666', kind=c_int32_t)
+    integer(c_int32_t) :: Gray41 = int(Z'696969', kind=c_int32_t)
+    integer(c_int32_t) :: Grey41 = int(Z'696969', kind=c_int32_t)
+    integer(c_int32_t) :: Gray42 = int(Z'6b6b6b', kind=c_int32_t)
+    integer(c_int32_t) :: Grey42 = int(Z'6b6b6b', kind=c_int32_t)
+    integer(c_int32_t) :: Gray43 = int(Z'6e6e6e', kind=c_int32_t)
+    integer(c_int32_t) :: Grey43 = int(Z'6e6e6e', kind=c_int32_t)
+    integer(c_int32_t) :: Gray44 = int(Z'707070', kind=c_int32_t)
+    integer(c_int32_t) :: Grey44 = int(Z'707070', kind=c_int32_t)
+    integer(c_int32_t) :: Gray45 = int(Z'737373', kind=c_int32_t)
+    integer(c_int32_t) :: Grey45 = int(Z'737373', kind=c_int32_t)
+    integer(c_int32_t) :: Gray46 = int(Z'757575', kind=c_int32_t)
+    integer(c_int32_t) :: Grey46 = int(Z'757575', kind=c_int32_t)
+    integer(c_int32_t) :: Gray47 = int(Z'787878', kind=c_int32_t)
+    integer(c_int32_t) :: Grey47 = int(Z'787878', kind=c_int32_t)
+    integer(c_int32_t) :: Gray48 = int(Z'7a7a7a', kind=c_int32_t)
+    integer(c_int32_t) :: Grey48 = int(Z'7a7a7a', kind=c_int32_t)
+    integer(c_int32_t) :: Gray49 = int(Z'7d7d7d', kind=c_int32_t)
+    integer(c_int32_t) :: Grey49 = int(Z'7d7d7d', kind=c_int32_t)
+    integer(c_int32_t) :: Gray50 = int(Z'7f7f7f', kind=c_int32_t)
+    integer(c_int32_t) :: Grey50 = int(Z'7f7f7f', kind=c_int32_t)
+    integer(c_int32_t) :: Gray51 = int(Z'828282', kind=c_int32_t)
+    integer(c_int32_t) :: Grey51 = int(Z'828282', kind=c_int32_t)
+    integer(c_int32_t) :: Gray52 = int(Z'858585', kind=c_int32_t)
+    integer(c_int32_t) :: Grey52 = int(Z'858585', kind=c_int32_t)
+    integer(c_int32_t) :: Gray53 = int(Z'878787', kind=c_int32_t)
+    integer(c_int32_t) :: Grey53 = int(Z'878787', kind=c_int32_t)
+    integer(c_int32_t) :: Gray54 = int(Z'8a8a8a', kind=c_int32_t)
+    integer(c_int32_t) :: Grey54 = int(Z'8a8a8a', kind=c_int32_t)
+    integer(c_int32_t) :: Gray55 = int(Z'8c8c8c', kind=c_int32_t)
+    integer(c_int32_t) :: Grey55 = int(Z'8c8c8c', kind=c_int32_t)
+    integer(c_int32_t) :: Gray56 = int(Z'8f8f8f', kind=c_int32_t)
+    integer(c_int32_t) :: Grey56 = int(Z'8f8f8f', kind=c_int32_t)
+    integer(c_int32_t) :: Gray57 = int(Z'919191', kind=c_int32_t)
+    integer(c_int32_t) :: Grey57 = int(Z'919191', kind=c_int32_t)
+    integer(c_int32_t) :: Gray58 = int(Z'949494', kind=c_int32_t)
+    integer(c_int32_t) :: Grey58 = int(Z'949494', kind=c_int32_t)
+    integer(c_int32_t) :: Gray59 = int(Z'969696', kind=c_int32_t)
+    integer(c_int32_t) :: Grey59 = int(Z'969696', kind=c_int32_t)
+    integer(c_int32_t) :: Gray60 = int(Z'999999', kind=c_int32_t)
+    integer(c_int32_t) :: Grey60 = int(Z'999999', kind=c_int32_t)
+    integer(c_int32_t) :: Gray61 = int(Z'9c9c9c', kind=c_int32_t)
+    integer(c_int32_t) :: Grey61 = int(Z'9c9c9c', kind=c_int32_t)
+    integer(c_int32_t) :: Gray62 = int(Z'9e9e9e', kind=c_int32_t)
+    integer(c_int32_t) :: Grey62 = int(Z'9e9e9e', kind=c_int32_t)
+    integer(c_int32_t) :: Gray63 = int(Z'a1a1a1', kind=c_int32_t)
+    integer(c_int32_t) :: Grey63 = int(Z'a1a1a1', kind=c_int32_t)
+    integer(c_int32_t) :: Gray64 = int(Z'a3a3a3', kind=c_int32_t)
+    integer(c_int32_t) :: Grey64 = int(Z'a3a3a3', kind=c_int32_t)
+    integer(c_int32_t) :: Gray65 = int(Z'a6a6a6', kind=c_int32_t)
+    integer(c_int32_t) :: Grey65 = int(Z'a6a6a6', kind=c_int32_t)
+    integer(c_int32_t) :: Gray66 = int(Z'a8a8a8', kind=c_int32_t)
+    integer(c_int32_t) :: Grey66 = int(Z'a8a8a8', kind=c_int32_t)
+    integer(c_int32_t) :: Gray67 = int(Z'ababab', kind=c_int32_t)
+    integer(c_int32_t) :: Grey67 = int(Z'ababab', kind=c_int32_t)
+    integer(c_int32_t) :: Gray68 = int(Z'adadad', kind=c_int32_t)
+    integer(c_int32_t) :: Grey68 = int(Z'adadad', kind=c_int32_t)
+    integer(c_int32_t) :: Gray69 = int(Z'b0b0b0', kind=c_int32_t)
+    integer(c_int32_t) :: Grey69 = int(Z'b0b0b0', kind=c_int32_t)
+    integer(c_int32_t) :: Gray70 = int(Z'b3b3b3', kind=c_int32_t)
+    integer(c_int32_t) :: Grey70 = int(Z'b3b3b3', kind=c_int32_t)
+    integer(c_int32_t) :: Gray71 = int(Z'b5b5b5', kind=c_int32_t)
+    integer(c_int32_t) :: Grey71 = int(Z'b5b5b5', kind=c_int32_t)
+    integer(c_int32_t) :: Gray72 = int(Z'b8b8b8', kind=c_int32_t)
+    integer(c_int32_t) :: Grey72 = int(Z'b8b8b8', kind=c_int32_t)
+    integer(c_int32_t) :: Gray73 = int(Z'bababa', kind=c_int32_t)
+    integer(c_int32_t) :: Grey73 = int(Z'bababa', kind=c_int32_t)
+    integer(c_int32_t) :: Gray74 = int(Z'bdbdbd', kind=c_int32_t)
+    integer(c_int32_t) :: Grey74 = int(Z'bdbdbd', kind=c_int32_t)
+    integer(c_int32_t) :: Gray75 = int(Z'bfbfbf', kind=c_int32_t)
+    integer(c_int32_t) :: Grey75 = int(Z'bfbfbf', kind=c_int32_t)
+    integer(c_int32_t) :: Gray76 = int(Z'c2c2c2', kind=c_int32_t)
+    integer(c_int32_t) :: Grey76 = int(Z'c2c2c2', kind=c_int32_t)
+    integer(c_int32_t) :: Gray77 = int(Z'c4c4c4', kind=c_int32_t)
+    integer(c_int32_t) :: Grey77 = int(Z'c4c4c4', kind=c_int32_t)
+    integer(c_int32_t) :: Gray78 = int(Z'c7c7c7', kind=c_int32_t)
+    integer(c_int32_t) :: Grey78 = int(Z'c7c7c7', kind=c_int32_t)
+    integer(c_int32_t) :: Gray79 = int(Z'c9c9c9', kind=c_int32_t)
+    integer(c_int32_t) :: Grey79 = int(Z'c9c9c9', kind=c_int32_t)
+    integer(c_int32_t) :: Gray80 = int(Z'cccccc', kind=c_int32_t)
+    integer(c_int32_t) :: Grey80 = int(Z'cccccc', kind=c_int32_t)
+    integer(c_int32_t) :: Gray81 = int(Z'cfcfcf', kind=c_int32_t)
+    integer(c_int32_t) :: Grey81 = int(Z'cfcfcf', kind=c_int32_t)
+    integer(c_int32_t) :: Gray82 = int(Z'd1d1d1', kind=c_int32_t)
+    integer(c_int32_t) :: Grey82 = int(Z'd1d1d1', kind=c_int32_t)
+    integer(c_int32_t) :: Gray83 = int(Z'd4d4d4', kind=c_int32_t)
+    integer(c_int32_t) :: Grey83 = int(Z'd4d4d4', kind=c_int32_t)
+    integer(c_int32_t) :: Gray84 = int(Z'd6d6d6', kind=c_int32_t)
+    integer(c_int32_t) :: Grey84 = int(Z'd6d6d6', kind=c_int32_t)
+    integer(c_int32_t) :: Gray85 = int(Z'd9d9d9', kind=c_int32_t)
+    integer(c_int32_t) :: Grey85 = int(Z'd9d9d9', kind=c_int32_t)
+    integer(c_int32_t) :: Gray86 = int(Z'dbdbdb', kind=c_int32_t)
+    integer(c_int32_t) :: Grey86 = int(Z'dbdbdb', kind=c_int32_t)
+    integer(c_int32_t) :: Gray87 = int(Z'dedede', kind=c_int32_t)
+    integer(c_int32_t) :: Grey87 = int(Z'dedede', kind=c_int32_t)
+    integer(c_int32_t) :: Gray88 = int(Z'e0e0e0', kind=c_int32_t)
+    integer(c_int32_t) :: Grey88 = int(Z'e0e0e0', kind=c_int32_t)
+    integer(c_int32_t) :: Gray89 = int(Z'e3e3e3', kind=c_int32_t)
+    integer(c_int32_t) :: Grey89 = int(Z'e3e3e3', kind=c_int32_t)
+    integer(c_int32_t) :: Gray90 = int(Z'e5e5e5', kind=c_int32_t)
+    integer(c_int32_t) :: Grey90 = int(Z'e5e5e5', kind=c_int32_t)
+    integer(c_int32_t) :: Gray91 = int(Z'e8e8e8', kind=c_int32_t)
+    integer(c_int32_t) :: Grey91 = int(Z'e8e8e8', kind=c_int32_t)
+    integer(c_int32_t) :: Gray92 = int(Z'ebebeb', kind=c_int32_t)
+    integer(c_int32_t) :: Grey92 = int(Z'ebebeb', kind=c_int32_t)
+    integer(c_int32_t) :: Gray93 = int(Z'ededed', kind=c_int32_t)
+    integer(c_int32_t) :: Grey93 = int(Z'ededed', kind=c_int32_t)
+    integer(c_int32_t) :: Gray94 = int(Z'f0f0f0', kind=c_int32_t)
+    integer(c_int32_t) :: Grey94 = int(Z'f0f0f0', kind=c_int32_t)
+    integer(c_int32_t) :: Gray95 = int(Z'f2f2f2', kind=c_int32_t)
+    integer(c_int32_t) :: Grey95 = int(Z'f2f2f2', kind=c_int32_t)
+    integer(c_int32_t) :: Gray96 = int(Z'f5f5f5', kind=c_int32_t)
+    integer(c_int32_t) :: Grey96 = int(Z'f5f5f5', kind=c_int32_t)
+    integer(c_int32_t) :: Gray97 = int(Z'f7f7f7', kind=c_int32_t)
+    integer(c_int32_t) :: Grey97 = int(Z'f7f7f7', kind=c_int32_t)
+    integer(c_int32_t) :: Gray98 = int(Z'fafafa', kind=c_int32_t)
+    integer(c_int32_t) :: Grey98 = int(Z'fafafa', kind=c_int32_t)
+    integer(c_int32_t) :: Gray99 = int(Z'fcfcfc', kind=c_int32_t)
+    integer(c_int32_t) :: Grey99 = int(Z'fcfcfc', kind=c_int32_t)
+    integer(c_int32_t) :: Gray100 = int(Z'ffffff', kind=c_int32_t)
+    integer(c_int32_t) :: Grey100 = int(Z'ffffff', kind=c_int32_t)
+    integer(c_int32_t) :: DarkGrey = int(Z'a9a9a9', kind=c_int32_t)
+    integer(c_int32_t) :: DarkGray = int(Z'a9a9a9', kind=c_int32_t)
+    integer(c_int32_t) :: DarkBlue = int(Z'00008b', kind=c_int32_t)
+    integer(c_int32_t) :: DarkCyan = int(Z'008b8b', kind=c_int32_t)
+    integer(c_int32_t) :: DarkMagenta = int(Z'8b008b', kind=c_int32_t)
+    integer(c_int32_t) :: DarkRed = int(Z'8b0000', kind=c_int32_t)
+    integer(c_int32_t) :: LightGreen = int(Z'90ee90', kind=c_int32_t)
+    integer(c_int32_t) :: Crimson = int(Z'dc143c', kind=c_int32_t)
+    integer(c_int32_t) :: Indigo = int(Z'4b0082', kind=c_int32_t)
+    integer(c_int32_t) :: Olive = int(Z'808000', kind=c_int32_t)
+    integer(c_int32_t) :: RebeccaPurple = int(Z'663399', kind=c_int32_t)
+    integer(c_int32_t) :: Silver = int(Z'c0c0c0', kind=c_int32_t)
+    integer(c_int32_t) :: Teal = int(Z'008080', kind=c_int32_t)
+  end type
+
+  interface
+    subroutine impl_tracy_set_thread_name(name) bind(C, name="___tracy_set_thread_name")
+      import
+      type(c_ptr), intent(in), value :: name
+    end subroutine impl_tracy_set_thread_name
+  end interface
+
+  type, bind(C) :: tracy_source_location_data
+    type(c_ptr) :: name
+    type(c_ptr) :: function
+    type(c_ptr) :: file
+    integer(c_int32_t) :: line
+    integer(c_int32_t) :: color
+  end type
+
+  type, bind(C) :: tracy_zone_context
+    integer(c_int32_t) :: id
+    integer(c_int32_t) :: active
+  end type
+
+  type, bind(C) :: tracy_gpu_time_data
+    integer(c_int64_t) :: gpuTime
+    integer(c_int16_t) :: queryId
+    integer(c_int8_t) :: context
+  end type
+
+  type, bind(C) :: tracy_gpu_zone_begin_data
+    integer(c_int64_t) :: srcloc
+    integer(c_int16_t) :: queryId
+    integer(c_int8_t) :: context
+  end type
+
+  type, bind(C) :: tracy_gpu_zone_begin_callstack_data
+    integer(c_int64_t) :: srcloc
+    integer(c_int32_t) :: depth
+    integer(c_int16_t) :: queryId
+    integer(c_int8_t) :: context
+  end type
+
+  type, bind(C) :: tracy_gpu_zone_end_data
+    integer(c_int16_t) :: queryId
+    integer(c_int8_t) :: context
+  end type
+
+  type, bind(C) :: tracy_gpu_new_context_data
+    integer(c_int64_t) :: gpuTime
+    real(c_float) :: period
+    integer(c_int8_t) :: context
+    integer(c_int8_t) :: flags
+    integer(c_int8_t) :: type
+  end type
+
+  type, bind(C) :: tracy_gpu_context_name_data
+    integer(c_int8_t) :: context
+    type(c_ptr) :: name
+    integer(c_int16_t) :: len
+  end type
+
+  type, bind(C) :: tracy_gpu_calibration_data
+    integer(c_int64_t) :: gpuTime
+    integer(c_int64_t) :: cpuDelta
+    integer(c_int8_t) :: context
+  end type
+
+  type, bind(C) :: tracy_gpu_time_sync_data
+    integer(c_int64_t) :: gpuTime
+    integer(c_int8_t) :: context
+  end type
+
+  ! tracy_lockable_context_data and related stuff is missed since Fortran does not have support of mutexes
+
+  interface
+    subroutine tracy_startup_profiler() bind(C, name="___tracy_startup_profiler")
+    end subroutine tracy_startup_profiler
+    subroutine tracy_shutdown_profiler() bind(C, name="___tracy_shutdown_profiler")
+    end subroutine tracy_shutdown_profiler
+    function impl_tracy_profiler_started() bind(C, name="___tracy_profiler_started")
+      import
+      integer(c_int32_t) :: impl_tracy_profiler_started
+    end function impl_tracy_profiler_started
+  end interface
+
+  interface
+    function impl_tracy_alloc_srcloc(line, source, sourceSz, function_name, functionSz, color) &
+      bind(C, name="___tracy_alloc_srcloc")
+      import
+      integer(c_int64_t) :: impl_tracy_alloc_srcloc
+      integer(c_int32_t), intent(in), value :: line
+      type(c_ptr), intent(in), value :: source
+      integer(c_size_t), intent(in), value :: sourceSz
+      type(c_ptr), intent(in), value :: function_name
+      integer(c_size_t), intent(in), value :: functionSz
+      integer(c_int32_t), intent(in), value :: color
+    end function impl_tracy_alloc_srcloc
+    function impl_tracy_alloc_srcloc_name(line, source, sourceSz, function_name, functionSz, zone_name, nameSz, color) &
+      bind(C, name="___tracy_alloc_srcloc_name")
+      import
+      integer(c_int64_t) :: impl_tracy_alloc_srcloc_name
+      integer(c_int32_t), intent(in), value :: line
+      type(c_ptr), intent(in), value :: source
+      integer(c_size_t), intent(in), value :: sourceSz
+      type(c_ptr), intent(in), value :: function_name
+      integer(c_size_t), intent(in), value :: functionSz
+      type(c_ptr), intent(in), value :: zone_name
+      integer(c_size_t), intent(in), value :: nameSz
+      integer(c_int32_t), intent(in), value :: color
+    end function impl_tracy_alloc_srcloc_name
+  end interface
+
+  interface
+    type(tracy_zone_context) function impl_tracy_emit_zone_begin_callstack(srcloc, depth, active) &
+      bind(C, name="___tracy_emit_zone_begin_callstack")
+      import
+      type(tracy_source_location_data), intent(in) :: srcloc
+      integer(c_int32_t), intent(in), value :: depth
+      integer(c_int32_t), intent(in), value :: active
+    end function impl_tracy_emit_zone_begin_callstack
+    type(tracy_zone_context) function impl_tracy_emit_zone_begin_alloc_callstack(srcloc, depth, active) &
+      bind(C, name="___tracy_emit_zone_begin_alloc_callstack")
+      import
+      integer(c_int64_t), intent(in), value :: srcloc
+      integer(c_int32_t), intent(in), value :: depth
+      integer(c_int32_t), intent(in), value :: active
+    end function impl_tracy_emit_zone_begin_alloc_callstack
+  end interface
+  interface tracy_zone_begin
+    module procedure tracy_emit_zone_begin_id, tracy_emit_zone_begin_type
+  end interface tracy_zone_begin
+
+  interface
+    subroutine tracy_zone_end(ctx) bind(C, name="___tracy_emit_zone_end")
+      import
+      type(tracy_zone_context), intent(in), value :: ctx
+    end subroutine tracy_zone_end
+  end interface
+
+  interface
+    subroutine tracy_emit_zone_text(ctx, txt, size) bind(C, name="___tracy_emit_zone_text")
+      import
+      type(tracy_zone_context), intent(in), value :: ctx
+      type(c_ptr), intent(in), value :: txt
+      integer(c_size_t), intent(in), value :: size
+    end subroutine tracy_emit_zone_text
+    subroutine tracy_emit_zone_name(ctx, txt, size) bind(C, name="___tracy_emit_zone_name")
+      import
+      type(tracy_zone_context), intent(in), value :: ctx
+      type(c_ptr), intent(in), value :: txt
+      integer(c_size_t), intent(in), value :: size
+    end subroutine tracy_emit_zone_name
+    subroutine tracy_emit_zone_color(ctx, color) bind(C, name="___tracy_emit_zone_color")
+      import
+      type(tracy_zone_context), intent(in), value :: ctx
+      integer(c_int32_t), intent(in), value :: color
+    end subroutine tracy_emit_zone_color
+    subroutine tracy_emit_zone_value(ctx, value) bind(C, name="___tracy_emit_zone_value")
+      import
+      type(tracy_zone_context), intent(in), value :: ctx
+      integer(c_int64_t), intent(in), value :: value
+    end subroutine tracy_emit_zone_value
+  end interface
+
+  ! GPU is not supported yet
+
+  interface
+    function impl_tracy_connected() bind(C, name="___tracy_connected")
+      import
+      integer(c_int32_t) :: impl_tracy_connected
+    end function impl_tracy_connected
+  end interface
+
+  interface
+    subroutine impl_tracy_emit_memory_alloc_callstack(ptr, size, depth, secure) &
+      bind(C, name="___tracy_emit_memory_alloc_callstack")
+      import
+      type(c_ptr), intent(in), value :: ptr
+      integer(c_size_t), intent(in), value :: size
+      integer(c_int32_t), intent(in), value :: depth
+      integer(c_int32_t), intent(in), value :: secure
+    end subroutine impl_tracy_emit_memory_alloc_callstack
+    subroutine impl_tracy_emit_memory_alloc_callstack_named(ptr, size, depth, secure, name) &
+      bind(C, name="___tracy_emit_memory_alloc_callstack_named")
+      import
+      type(c_ptr), intent(in), value :: ptr
+      integer(c_size_t), intent(in), value :: size
+      integer(c_int32_t), intent(in), value :: depth
+      integer(c_int32_t), intent(in), value :: secure
+      type(c_ptr), intent(in), value :: name
+    end subroutine impl_tracy_emit_memory_alloc_callstack_named
+    subroutine impl_tracy_emit_memory_free_callstack(ptr, depth, secure) &
+      bind(C, name="___tracy_emit_memory_free_callstack")
+      import
+      type(c_ptr), intent(in), value :: ptr
+      integer(c_int32_t), intent(in), value :: depth
+      integer(c_int32_t), intent(in), value :: secure
+    end subroutine impl_tracy_emit_memory_free_callstack
+    subroutine impl_tracy_emit_memory_free_callstack_named(ptr, depth, secure, name) &
+      bind(C, name="___tracy_emit_memory_free_callstack_named")
+      import
+      type(c_ptr), intent(in), value :: ptr
+      integer(c_int32_t), intent(in), value :: depth
+      integer(c_int32_t), intent(in), value :: secure
+      type(c_ptr), intent(in), value :: name
+    end subroutine impl_tracy_emit_memory_free_callstack_named
+    subroutine impl_tracy_emit_memory_discard_callstack(name, secure, depth) &
+      bind(C, name="___tracy_emit_memory_discard_callstack")
+      import
+      type(c_ptr), intent(in), value :: name
+      integer(c_int32_t), intent(in), value :: secure
+      integer(c_int32_t), intent(in), value :: depth
+    end subroutine impl_tracy_emit_memory_discard_callstack
+  end interface
+
+  interface
+    subroutine impl_tracy_emit_message(txt, size, depth) &
+      bind(C, name="___tracy_emit_message")
+      import
+      type(c_ptr), intent(in), value :: txt
+      integer(c_size_t), value :: size
+      integer(c_int32_t), value :: depth
+    end subroutine impl_tracy_emit_message
+    subroutine impl_tracy_emit_messageC(txt, size, color, depth) &
+      bind(C, name="___tracy_emit_messageC")
+      import
+      type(c_ptr), intent(in), value :: txt
+      integer(c_size_t), value :: size
+      integer(c_int32_t), value :: color
+      integer(c_int32_t), value :: depth
+    end subroutine impl_tracy_emit_messageC
+    subroutine impl_tracy_emit_message_appinfo(txt, size) &
+      bind(C, name="___tracy_emit_message_appinfo")
+      import
+      type(c_ptr), intent(in), value :: txt
+      integer(c_size_t), value :: size
+    end subroutine impl_tracy_emit_message_appinfo
+  end interface
+
+  interface
+    subroutine impl_tracy_emit_frame_mark(name) &
+      bind(C, name="___tracy_emit_frame_mark")
+      import
+      type(c_ptr), intent(in), value :: name
+    end subroutine impl_tracy_emit_frame_mark
+    subroutine impl_tracy_emit_frame_mark_start(name) &
+      bind(C, name="___tracy_emit_frame_mark_start")
+      import
+      type(c_ptr), intent(in), value :: name
+    end subroutine impl_tracy_emit_frame_mark_start
+    subroutine impl_tracy_emit_frame_mark_end(name) &
+      bind(C, name="___tracy_emit_frame_mark_end")
+      import
+      type(c_ptr), intent(in), value :: name
+    end subroutine impl_tracy_emit_frame_mark_end
+  end interface
+
+  interface
+    subroutine impl_tracy_emit_frame_image(image, w, h, offset, flip) &
+      bind(C, name="___tracy_emit_frame_image")
+      import
+      type(c_ptr), intent(in), value :: image
+      integer(c_int16_t), intent(in), value :: w
+      integer(c_int16_t), intent(in), value :: h
+      integer(c_int8_t), intent(in), value :: offset
+      integer(c_int32_t), intent(in), value :: flip
+    end subroutine impl_tracy_emit_frame_image
+  end interface
+
+  interface
+    subroutine impl_tracy_emit_plot_int8(name, val) &
+      bind(C, name="___tracy_emit_plot_int")
+      import
+      type(c_ptr), intent(in), value :: name
+      integer(c_int64_t), value :: val
+    end subroutine impl_tracy_emit_plot_int8
+    subroutine impl_tracy_emit_plot_real4(name, val) &
+      bind(C, name="___tracy_emit_plot_float")
+      import
+      type(c_ptr), intent(in), value :: name
+      real(c_float), value :: val
+    end subroutine impl_tracy_emit_plot_real4
+    subroutine impl_tracy_emit_plot_real8(name, val) &
+      bind(C, name="___tracy_emit_plot")
+      import
+      type(c_ptr), intent(in), value :: name
+      real(c_double), value :: val
+    end subroutine impl_tracy_emit_plot_real8
+  end interface
+  interface tracy_plot
+    module procedure tracy_plot_int8, tracy_plot_real4, tracy_plot_real8
+  end interface tracy_plot
+  interface
+    subroutine impl_tracy_emit_plot_config(name, type, step, fill, color) &
+      bind(C, name="___tracy_emit_plot_config")
+      import
+      type(c_ptr), intent(in), value :: name
+      integer(c_int32_t), intent(in), value :: type
+      integer(c_int32_t), intent(in), value :: step
+      integer(c_int32_t), intent(in), value :: fill
+      integer(c_int32_t), intent(in), value :: color
+    end subroutine impl_tracy_emit_plot_config
+  end interface
+
+#ifdef TRACY_FIBERS
+  interface
+    subroutine impl_tracy_fiber_enter(fiber_name) &
+      bind(C, name="___tracy_fiber_enter")
+      import
+      type(c_ptr), intent(in), value :: fiber_name
+    end subroutine impl_tracy_fiber_enter
+    subroutine tracy_fiber_leave() &
+      bind(C, name="___tracy_fiber_leave")
+    end subroutine tracy_fiber_leave
+  end interface
+#endif
+  !
+  public :: tracy_zone_context
+  public :: tracy_source_location_data
+  !
+#ifndef __SUNPRO_F90
+  type(TracyColors_t), public, parameter :: TracyColors = TracyColors_t()
+#endif
+  !
+  public :: tracy_set_thread_name
+  public :: tracy_startup_profiler, tracy_shutdown_profiler, tracy_profiler_started
+  public :: tracy_connected
+  public :: tracy_appinfo
+  public :: tracy_alloc_srcloc
+  public :: tracy_zone_begin, tracy_zone_end
+  public :: tracy_zone_set_properties
+  public :: tracy_frame_mark, tracy_frame_start, tracy_frame_end
+  public :: tracy_memory_alloc, tracy_memory_free, tracy_memory_discard
+  public :: tracy_message
+  public :: tracy_image
+  public :: tracy_plot_config, tracy_plot
+#ifdef TRACY_FIBERS
+  public :: tracy_fiber_enter, tracy_fiber_leave
+#endif
+contains
+  subroutine tracy_set_thread_name(name)
+    character(kind=c_char, len=*), intent(in) :: name
+    character(kind=c_char, len=:), allocatable, target :: alloc_name
+    allocate (character(kind=c_char, len=len(name) + 1) :: alloc_name)
+    alloc_name = name//c_null_char
+    call impl_tracy_set_thread_name(c_loc(alloc_name))
+  end subroutine tracy_set_thread_name
+
+  logical(1) function tracy_profiler_started()
+    tracy_profiler_started = impl_tracy_profiler_started() /= 0_c_int
+  end function tracy_profiler_started
+
+  integer(c_int64_t) function tracy_alloc_srcloc(line, source, function_name, zone_name, color)
+    integer(c_int32_t), intent(in) :: line
+    character(kind=c_char, len=*), target, intent(in) :: source, function_name
+    character(kind=c_char, len=*), target, intent(in), optional :: zone_name
+    integer(c_int32_t), intent(in), optional :: color
+    !
+    integer(c_int32_t) :: color_
+    !
+    color_ = 0_c_int32_t
+    if (present(color)) color_ = color
+    if (present(zone_name)) then
+      tracy_alloc_srcloc = impl_tracy_alloc_srcloc_name(line, &
+                                                        c_loc(source), len(source, kind=c_size_t), &
+                                                        c_loc(function_name), len(function_name, kind=c_size_t), &
+                                                        c_loc(zone_name), len(zone_name, kind=c_size_t), &
+                                                        color_)
+    else
+      tracy_alloc_srcloc = impl_tracy_alloc_srcloc(line, &
+                                                   c_loc(source), len(source, kind=c_size_t), &
+                                                   c_loc(function_name), len(function_name, kind=c_size_t), &
+                                                   color_)
+    end if
+  end function tracy_alloc_srcloc
+
+  type(tracy_zone_context) function tracy_emit_zone_begin_id(srcloc, depth, active)
+    integer(c_int64_t), intent(inout) :: srcloc
+    integer(c_int32_t), intent(in), optional :: depth
+    logical(1), intent(in), optional :: active
+    !
+    integer(c_int32_t) :: depth_
+    integer(c_int32_t) :: active_
+    active_ = 1_c_int32_t
+    depth_ = 0_c_int32_t
+    if (present(active)) then
+      if (active) then
+        active_ = 1_c_int32_t
+      else
+        active_ = 0_c_int32_t
+      end if
+    end if
+    if (present(depth)) depth_ = depth
+    tracy_emit_zone_begin_id = impl_tracy_emit_zone_begin_alloc_callstack(srcloc, depth_, active_)
+    srcloc = 0_c_int64_t
+  end function tracy_emit_zone_begin_id
+  type(tracy_zone_context) function tracy_emit_zone_begin_type(srcloc, depth, active)
+    type(tracy_source_location_data), intent(inout) :: srcloc
+    integer(c_int32_t), intent(in), optional :: depth
+    logical(1), intent(in), optional :: active
+    !
+    integer(c_int32_t) :: depth_
+    integer(c_int32_t) :: active_
+    active_ = 1_c_int32_t
+    depth_ = 0_c_int32_t
+    if (present(active)) then
+      if (active) then
+        active_ = 1_c_int32_t
+      else
+        active_ = 0_c_int32_t
+      end if
+    end if
+    if (present(depth)) depth_ = depth
+    tracy_emit_zone_begin_type = impl_tracy_emit_zone_begin_callstack(srcloc, depth_, active_)
+    srcloc = tracy_source_location_data(c_null_ptr, c_null_ptr, c_null_ptr, 0_c_int32_t, 0_c_int32_t)
+  end function tracy_emit_zone_begin_type
+
+  subroutine tracy_zone_set_properties(ctx, text, name, color, value)
+    type(tracy_zone_context), intent(in), value :: ctx
+    character(kind=c_char, len=*), target, intent(in), optional :: text
+    character(kind=c_char, len=*), target, intent(in), optional :: name
+    integer(c_int32_t), target, intent(in), optional :: color
+    integer(c_int64_t), target, intent(in), optional :: value
+    if (present(text)) then
+      call tracy_emit_zone_text(ctx, c_loc(text), len(text, kind=c_size_t))
+    end if
+    if (present(name)) then
+      call tracy_emit_zone_name(ctx, c_loc(name), len(name, kind=c_size_t))
+    end if
+    if (present(color)) then
+      call tracy_emit_zone_color(ctx, color)
+    end if
+    if (present(value)) then
+      call tracy_emit_zone_value(ctx, value)
+    end if
+  end subroutine tracy_zone_set_properties
+
+  logical(1) function tracy_connected()
+    tracy_connected = impl_tracy_connected() /= 0_c_int32_t
+  end function tracy_connected
+
+  subroutine tracy_memory_alloc(ptr, size, name, depth, secure)
+    type(c_ptr), intent(in) :: ptr
+    integer(c_size_t), intent(in) :: size
+    character(kind=c_char, len=*), target, intent(in), optional :: name
+    integer(c_int32_t), intent(in), optional :: depth
+    logical(1), intent(in), optional :: secure
+    !
+    integer(c_int32_t) :: depth_, secure_
+    secure_ = 0_c_int32_t
+    depth_ = 0_c_int32_t
+    if (present(secure)) then
+      if (secure) secure_ = 1_c_int32_t
+    end if
+    if (present(depth)) depth_ = depth
+    if (present(name)) then
+      call impl_tracy_emit_memory_alloc_callstack_named(ptr, size, depth_, secure_, c_loc(name))
+    else
+      call impl_tracy_emit_memory_alloc_callstack(ptr, size, depth_, secure_)
+    end if
+  end subroutine tracy_memory_alloc
+  subroutine tracy_memory_free(ptr, name, depth, secure)
+    type(c_ptr), intent(in) :: ptr
+    character(kind=c_char, len=*), target, intent(in), optional :: name
+    integer(c_int32_t), intent(in), optional :: depth
+    logical(1), intent(in), optional :: secure
+    !
+    integer(c_int32_t) :: depth_, secure_
+    secure_ = 0_c_int32_t
+    depth_ = 0_c_int32_t
+    if (present(secure)) then
+      if (secure) secure_ = 1_c_int32_t
+    end if
+    if (present(depth)) depth_ = depth
+    if (present(name)) then
+      call impl_tracy_emit_memory_free_callstack_named(ptr, depth_, secure_, c_loc(name))
+    else
+      call impl_tracy_emit_memory_free_callstack(ptr, depth_, secure_)
+    end if
+  end subroutine tracy_memory_free
+  subroutine tracy_memory_discard(name, depth, secure)
+    character(kind=c_char, len=*), target, intent(in) :: name
+    integer(c_int32_t), intent(in), optional :: depth
+    logical(1), intent(in), optional :: secure
+    !
+    integer(c_int32_t) :: depth_, secure_
+    secure_ = 0_c_int32_t
+    depth_ = 0_c_int32_t
+    if (present(secure)) then
+      if (secure) secure_ = 1_c_int32_t
+    end if
+    if (present(depth)) depth_ = depth
+    call impl_tracy_emit_memory_discard_callstack(c_loc(name), depth_, secure_)
+  end subroutine tracy_memory_discard
+
+  subroutine tracy_message(msg, color, depth)
+    character(kind=c_char, len=*), target, intent(in) :: msg
+    integer(c_int32_t), intent(in), optional :: color
+    integer(c_int32_t), intent(in), optional :: depth
+    !
+    integer(c_int32_t) :: depth_
+    depth_ = 0_c_int32_t
+    if (present(depth)) depth_ = depth
+    if (present(color)) then
+      call impl_tracy_emit_messageC(c_loc(msg), len(msg, kind=c_size_t), color, depth_)
+    else
+      call impl_tracy_emit_message(c_loc(msg), len(msg, kind=c_size_t), depth_)
+    end if
+  end subroutine tracy_message
+
+  subroutine tracy_appinfo(info)
+    character(kind=c_char, len=*), target, intent(in) :: info
+    call impl_tracy_emit_message_appinfo(c_loc(info), len(info, kind=c_size_t))
+  end subroutine tracy_appinfo
+
+  subroutine tracy_frame_mark(name)
+    character(kind=c_char, len=*), target, intent(in), optional :: name
+    if (present(name)) then
+      call impl_tracy_emit_frame_mark(c_loc(name))
+    else
+      call impl_tracy_emit_frame_mark(c_null_ptr)
+    end if
+  end subroutine tracy_frame_mark
+  subroutine tracy_frame_start(name)
+    character(kind=c_char, len=*), target, intent(in), optional :: name
+    if (present(name)) then
+      call impl_tracy_emit_frame_mark_start(c_loc(name))
+    else
+      call impl_tracy_emit_frame_mark_start(c_null_ptr)
+    end if
+  end subroutine tracy_frame_start
+  subroutine tracy_frame_end(name)
+    character(kind=c_char, len=*), target, intent(in), optional :: name
+    if (present(name)) then
+      call impl_tracy_emit_frame_mark_end(c_loc(name))
+    else
+      call impl_tracy_emit_frame_mark_end(c_null_ptr)
+    end if
+  end subroutine tracy_frame_end
+
+  subroutine tracy_image(image, w, h, offset, flip)
+    type(c_ptr), intent(in) :: image
+    integer(c_int16_t), intent(in) :: w, h
+    integer(c_int8_t), intent(in), optional :: offset
+    logical(1), intent(in), optional :: flip
+    !
+    integer(c_int32_t) :: flip_
+    integer(c_int8_t) :: offset_
+    flip_ = 0_c_int32_t
+    offset_ = 0_c_int8_t
+    if (present(flip)) then
+      if (flip) flip_ = 1_c_int32_t
+    end if
+    if (present(offset)) offset_ = offset
+    call impl_tracy_emit_frame_image(image, w, h, offset_, flip_)
+  end subroutine tracy_image
+
+  subroutine tracy_plot_int8(name, val)
+    character(kind=c_char, len=*), target, intent(in) :: name
+    integer(c_int64_t) :: val
+    call impl_tracy_emit_plot_int8(c_loc(name), val)
+  end subroutine tracy_plot_int8
+  subroutine tracy_plot_real4(name, val)
+    character(kind=c_char, len=*), target, intent(in) :: name
+    real(c_float) :: val
+    call impl_tracy_emit_plot_real4(c_loc(name), val)
+  end subroutine tracy_plot_real4
+  subroutine tracy_plot_real8(name, val)
+    character(kind=c_char, len=*), target, intent(in) :: name
+    real(c_double) :: val
+    call impl_tracy_emit_plot_real8(c_loc(name), val)
+  end subroutine tracy_plot_real8
+
+  subroutine tracy_plot_config(name, type, step, fill, color)
+    character(kind=c_char, len=*), target, intent(in) :: name
+    integer(c_int32_t), intent(in), optional :: type
+    logical(1), intent(in), optional :: step
+    logical(1), intent(in), optional :: fill
+    integer(c_int32_t), intent(in), optional :: color
+    !
+    integer(c_int32_t) :: type_, step_, fill_, color_
+    type_ = 0_c_int32_t
+    step_ = 0_c_int32_t
+    fill_ = 1_c_int32_t
+    color_ = 0_c_int32_t
+    if (present(type)) type_ = type
+    if (present(step)) then
+      if (step) step_ = 1_c_int32_t
+    end if
+    if (present(fill)) then
+      if (.not. fill) fill_ = 0_c_int32_t
+    end if
+    if (present(color)) color_ = color
+    call impl_tracy_emit_plot_config(c_loc(name), type_, step_, fill_, color_)
+  end subroutine tracy_plot_config
+
+#ifdef TRACY_FIBERS
+  subroutine tracy_fiber_enter(fiber_name)
+    character(kind=c_char, len=*), target, intent(in) :: fiber_name
+    call impl_tracy_fiber_enter(c_loc(fiber_name))
+  end subroutine tracy_fiber_enter
+#endif
+end module tracy

--- a/tracy-client-sys/tracy/client/TracyCallstack.cpp
+++ b/tracy-client-sys/tracy/client/TracyCallstack.cpp
@@ -282,7 +282,12 @@ extern "C"
     t_SymFromInlineContext _SymFromInlineContext = 0;
     t_SymGetLineFromInlineContext _SymGetLineFromInlineContext = 0;
 
-    TRACY_API ___tracy_t_RtlWalkFrameChain ___tracy_RtlWalkFrameChain = 0;
+    typedef unsigned long (__stdcall *___tracy_t_RtlWalkFrameChain)( void**, unsigned long, unsigned long );
+    ___tracy_t_RtlWalkFrameChain ___tracy_RtlWalkFrameChainPtr = nullptr;
+    TRACY_API unsigned long ___tracy_RtlWalkFrameChain( void** callers, unsigned long count, unsigned long flags)
+    {
+        return ___tracy_RtlWalkFrameChainPtr(callers, count, flags);
+    }
 }
 
 struct ModuleCache
@@ -307,7 +312,7 @@ size_t s_krnlCacheCnt;
 
 void InitCallstackCritical()
 {
-    ___tracy_RtlWalkFrameChain = (___tracy_t_RtlWalkFrameChain)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "RtlWalkFrameChain" );
+    ___tracy_RtlWalkFrameChainPtr = (___tracy_t_RtlWalkFrameChain)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "RtlWalkFrameChain" );
 }
 
 void DbgHelpInit()

--- a/tracy-client-sys/tracy/client/TracyCallstack.hpp
+++ b/tracy-client-sys/tracy/client/TracyCallstack.hpp
@@ -9,7 +9,8 @@
 
 namespace tracy
 {
-static tracy_force_inline void* Callstack( int /*depth*/ ) { return nullptr; }
+static constexpr bool has_callstack() { return false; }
+static tracy_force_inline void* Callstack( int32_t /*depth*/ ) { return nullptr; }
 }
 
 #else
@@ -37,6 +38,8 @@ static tracy_force_inline void* Callstack( int /*depth*/ ) { return nullptr; }
 
 namespace tracy
 {
+
+static constexpr bool has_callstack() { return true; }
 
 struct CallstackSymbolData
 {
@@ -79,11 +82,10 @@ debuginfod_client* GetDebuginfodClient();
 
 extern "C"
 {
-    typedef unsigned long (__stdcall *___tracy_t_RtlWalkFrameChain)( void**, unsigned long, unsigned long );
-    TRACY_API extern ___tracy_t_RtlWalkFrameChain ___tracy_RtlWalkFrameChain;
+    TRACY_API unsigned long ___tracy_RtlWalkFrameChain( void**, unsigned long, unsigned long );
 }
 
-static tracy_force_inline void* Callstack( int depth )
+static tracy_force_inline void* Callstack( int32_t depth )
 {
     assert( depth >= 1 && depth < 63 );
     auto trace = (uintptr_t*)tracy_malloc( ( 1 + depth ) * sizeof( uintptr_t ) );
@@ -112,7 +114,7 @@ static _Unwind_Reason_Code tracy_unwind_callback( struct _Unwind_Context* ctx, v
     return _URC_NO_REASON;
 }
 
-static tracy_force_inline void* Callstack( int depth )
+static tracy_force_inline void* Callstack( int32_t depth )
 {
     assert( depth >= 1 && depth < 63 );
 
@@ -127,7 +129,7 @@ static tracy_force_inline void* Callstack( int depth )
 
 #elif TRACY_HAS_CALLSTACK == 3 || TRACY_HAS_CALLSTACK == 4 || TRACY_HAS_CALLSTACK == 6
 
-static tracy_force_inline void* Callstack( int depth )
+static tracy_force_inline void* Callstack( int32_t depth )
 {
     assert( depth >= 1 );
 

--- a/tracy-client-sys/tracy/client/TracyProfiler.cpp
+++ b/tracy-client-sys/tracy/client/TracyProfiler.cpp
@@ -81,6 +81,10 @@
 #include "TracySysTrace.hpp"
 #include "../tracy/TracyC.h"
 
+#if defined TRACY_MANUAL_LIFETIME && !defined(TRACY_DELAYED_INIT)
+#  error "TRACY_MANUAL_LIFETIME requires enabled TRACY_DELAYED_INIT"
+#endif
+
 #ifdef TRACY_PORT
 #  ifndef TRACY_DATA_PORT
 #    define TRACY_DATA_PORT TRACY_PORT
@@ -106,9 +110,12 @@
 #  include <lmcons.h>
 extern "C" typedef LONG (WINAPI *t_RtlGetVersion)( PRTL_OSVERSIONINFOW );
 extern "C" typedef BOOL (WINAPI *t_GetLogicalProcessorInformationEx)( LOGICAL_PROCESSOR_RELATIONSHIP, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PDWORD );
+extern "C" typedef char* (WINAPI *t_WineGetVersion)();
+extern "C" typedef char* (WINAPI *t_WineGetBuildId)();
 #else
 #  include <unistd.h>
 #  include <limits.h>
+#  include <fcntl.h>
 #endif
 #if defined __linux__
 #  include <sys/sysinfo.h>
@@ -521,7 +528,16 @@ static const char* GetHostInfo()
 #  ifdef __MINGW32__
         ptr += sprintf( ptr, "OS: Windows %i.%i.%i (MingW)\n", (int)ver.dwMajorVersion, (int)ver.dwMinorVersion, (int)ver.dwBuildNumber );
 #  else
-        ptr += sprintf( ptr, "OS: Windows %lu.%lu.%lu\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
+        auto WineGetVersion = (t_WineGetVersion)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "wine_get_version" );
+        auto WineGetBuildId = (t_WineGetBuildId)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "wine_get_build_id" );
+        if( WineGetVersion && WineGetBuildId )
+        {
+            ptr += sprintf( ptr, "OS: Windows %lu.%lu.%lu (Wine %s [%s])\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber, WineGetVersion(), WineGetBuildId() );
+        }
+        else
+        {
+            ptr += sprintf( ptr, "OS: Windows %lu.%lu.%lu\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
+        }
 #  endif
     }
 #elif defined __linux__
@@ -1378,6 +1394,8 @@ TRACY_API LuaZoneState& GetLuaZoneState() { return s_luaZoneState; }
 TRACY_API bool ProfilerAvailable() { return s_instance != nullptr; }
 TRACY_API bool ProfilerAllocatorAvailable() { return !RpThreadShutdown; }
 
+constexpr static size_t SafeSendBufferSize = 65536;
+
 Profiler::Profiler()
     : m_timeBegin( 0 )
     , m_mainThread( detail::GetThreadHandleImpl() )
@@ -1451,6 +1469,21 @@ Profiler::Profiler()
         m_userPort = atoi( userPort );
     }
 
+    m_safeSendBuffer = (char*)tracy_malloc( SafeSendBufferSize );
+
+#ifndef _WIN32
+    pipe(m_pipe);
+#  if defined __APPLE__ || defined BSD
+    // FreeBSD/XNU don't have F_SETPIPE_SZ, so use the default
+    m_pipeBufSize = 16384;
+#  else
+    m_pipeBufSize = (int)(ptrdiff_t)SafeSendBufferSize;
+    while( fcntl( m_pipe[0], F_SETPIPE_SZ, m_pipeBufSize ) < 0 && errno == EPERM ) m_pipeBufSize /= 2; // too big; reduce
+    m_pipeBufSize = fcntl( m_pipe[0], F_GETPIPE_SZ );
+#  endif
+    fcntl( m_pipe[1], F_SETFL, O_NONBLOCK );
+#endif
+
 #if !defined(TRACY_DELAYED_INIT) || !defined(TRACY_MANUAL_LIFETIME)
     SpawnWorkerThreads();
 #endif
@@ -1476,7 +1509,9 @@ void Profiler::InstallCrashHandler()
 #endif
 
 #if defined _WIN32 && !defined TRACY_UWP && !defined TRACY_NO_CRASH_HANDLER
-    m_exceptionHandler = AddVectoredExceptionHandler( 1, CrashFilter );
+    // We cannot use Vectored Exception handling because it catches application-wide frame-based SEH blocks. We only
+    // want to catch unhandled exceptions.
+    m_prevHandler = SetUnhandledExceptionFilter( CrashFilter );
 #endif
 
 #ifndef TRACY_NO_CRASH_HANDLER
@@ -1487,20 +1522,29 @@ void Profiler::InstallCrashHandler()
 
 void Profiler::RemoveCrashHandler()
 {
-#if defined _WIN32 && !defined TRACY_UWP
-    if( m_crashHandlerInstalled ) RemoveVectoredExceptionHandler( m_exceptionHandler );
+#if defined _WIN32 && !defined TRACY_UWP && !defined TRACY_NO_CRASH_HANDLER
+    if( m_crashHandlerInstalled )
+    {
+        auto prev = SetUnhandledExceptionFilter( (LPTOP_LEVEL_EXCEPTION_FILTER)m_prevHandler );
+        if( prev != CrashFilter ) SetUnhandledExceptionFilter( prev ); // A different exception filter was installed over ours => put it back
+    }
 #endif
 
 #if defined __linux__ && !defined TRACY_NO_CRASH_HANDLER
     if( m_crashHandlerInstalled )
     {
-        sigaction( TRACY_CRASH_SIGNAL, &m_prevSignal.pwr, nullptr );
-        sigaction( SIGILL, &m_prevSignal.ill, nullptr );
-        sigaction( SIGFPE, &m_prevSignal.fpe, nullptr );
-        sigaction( SIGSEGV, &m_prevSignal.segv, nullptr );
-        sigaction( SIGPIPE, &m_prevSignal.pipe, nullptr );
-        sigaction( SIGBUS, &m_prevSignal.bus, nullptr );
-        sigaction( SIGABRT, &m_prevSignal.abrt, nullptr );
+        auto restore = []( int signum, struct sigaction* prev ) {
+            struct sigaction old;
+            sigaction( signum, prev, &old );
+            if( old.sa_sigaction != CrashHandler ) sigaction( signum, &old, nullptr ); // A different signal handler was installed over ours => put it back
+        };
+        restore( TRACY_CRASH_SIGNAL, &m_prevSignal.pwr );
+        restore( SIGILL, &m_prevSignal.ill );
+        restore( SIGFPE, &m_prevSignal.fpe );
+        restore( SIGSEGV, &m_prevSignal.segv );
+        restore( SIGPIPE, &m_prevSignal.pipe );
+        restore( SIGBUS, &m_prevSignal.bus );
+        restore( SIGABRT, &m_prevSignal.abrt );
     }
 #endif
     m_crashHandlerInstalled = false;
@@ -1588,6 +1632,12 @@ Profiler::~Profiler()
     m_kcore->~KCore();
     tracy_free( m_kcore );
 #endif
+
+#ifndef _WIN32
+    close( m_pipe[0] );
+    close( m_pipe[1] );
+#endif
+    tracy_free( m_safeSendBuffer );
 
     tracy_free( m_lz4Buf );
     tracy_free( m_buffer );
@@ -2816,6 +2866,15 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
                     MemWrite( &item->memFree.time, dt );
                     break;
                 }
+                case QueueType::MemDiscard:
+                case QueueType::MemDiscardCallstack:
+                {
+                    int64_t t = MemRead<int64_t>( &item->memDiscard.time );
+                    int64_t dt = t - refSerial;
+                    refSerial = t;
+                    MemWrite( &item->memDiscard.time, dt );
+                    break;
+                }
                 case QueueType::GpuZoneBeginSerial:
                 case QueueType::GpuZoneBeginCallstackSerial:
                 {
@@ -3050,6 +3109,62 @@ bool Profiler::CommitData()
     if( m_bufferOffset > TargetFrameSize * 2 ) m_bufferOffset = 0;
     m_bufferStart = m_bufferOffset;
     return ret;
+}
+
+char* Profiler::SafeCopyProlog( const char* data, size_t size )
+{
+    bool success = true;
+    char* buf = m_safeSendBuffer;
+#ifndef NDEBUG
+    assert( !m_inUse.exchange(true) );
+#endif
+
+    if( size > SafeSendBufferSize ) buf = (char*)tracy_malloc( size );
+
+#ifdef _WIN32
+    __try
+    {
+        memcpy( buf, data, size );
+    }
+    __except( 1 /*EXCEPTION_EXECUTE_HANDLER*/ )
+    {
+        success = false;
+    }
+#else
+    // Send through the pipe to ensure safe reads
+    for( size_t offset = 0; offset != size; /*in loop*/ )
+    {
+        size_t sendsize = size - offset;
+        ssize_t result1, result2;
+        while( ( result1 = write( m_pipe[1], data + offset, sendsize ) ) < 0 && errno == EINTR ) { /* retry */ }
+        if( result1 < 0 )
+        {
+            success = false;
+            break;
+        }
+        while( ( result2 = read( m_pipe[0], buf + offset, result1 ) ) < 0 && errno == EINTR ) { /* retry */ }
+        if( result2 != result1 )
+        {
+            success = false;
+            break;
+        }
+        offset += result1;
+    }
+#endif
+
+    if( success ) return buf;
+
+    SafeCopyEpilog( buf );
+    return nullptr;
+}
+
+void Profiler::SafeCopyEpilog( char* buf )
+{
+    if( buf != m_safeSendBuffer ) tracy_free( buf );
+
+#ifndef NDEBUG
+    m_inUse.store( false );
+#endif
 }
 
 bool Profiler::SendData( const char* data, size_t len )
@@ -3740,17 +3855,48 @@ void Profiler::ReportTopology()
 #  endif
     if( !_GetLogicalProcessorInformationEx ) return;
 
+    SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* packageInfo = nullptr;
+    SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* dieInfo = nullptr;
+    SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX* coreInfo = nullptr;
+
     DWORD psz = 0;
     _GetLogicalProcessorInformationEx( RelationProcessorPackage, nullptr, &psz );
-    auto packageInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( psz );
-    auto res = _GetLogicalProcessorInformationEx( RelationProcessorPackage, packageInfo, &psz );
-    assert( res );
+    if( GetLastError() == ERROR_INSUFFICIENT_BUFFER )
+    {
+        packageInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( psz );
+        auto res = _GetLogicalProcessorInformationEx( RelationProcessorPackage, packageInfo, &psz );
+        assert( res );
+    }
+    else
+    {
+        psz = 0;
+    }
+
+    DWORD dsz = 0;
+    _GetLogicalProcessorInformationEx( RelationProcessorDie, nullptr, &dsz );
+    if( GetLastError() == ERROR_INSUFFICIENT_BUFFER )
+    {
+        dieInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( dsz );
+        auto res = _GetLogicalProcessorInformationEx( RelationProcessorDie, dieInfo, &dsz );
+        assert( res );
+    }
+    else
+    {
+        dsz = 0;
+    }
 
     DWORD csz = 0;
     _GetLogicalProcessorInformationEx( RelationProcessorCore, nullptr, &csz );
-    auto coreInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( csz );
-    res = _GetLogicalProcessorInformationEx( RelationProcessorCore, coreInfo, &csz );
-    assert( res );
+    if( GetLastError() == ERROR_INSUFFICIENT_BUFFER )
+    {
+        coreInfo = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)tracy_malloc( csz );
+        auto res = _GetLogicalProcessorInformationEx( RelationProcessorCore, coreInfo, &csz );
+        assert( res );
+    }
+    else
+    {
+        csz = 0;
+    }
 
     SYSTEM_INFO sysinfo;
     GetSystemInfo( &sysinfo );
@@ -3771,6 +3917,24 @@ void Profiler::ReportTopology()
         while( mask != 0 )
         {
             if( mask & 1 ) cpuData[core].package = idx;
+            core++;
+            mask >>= 1;
+        }
+        ptr = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*)(((char*)ptr) + ptr->Size);
+        idx++;
+    }
+
+    idx = 0;
+    ptr = dieInfo;
+    while( (char*)ptr < ((char*)dieInfo) + dsz )
+    {
+        assert( ptr->Relationship == RelationProcessorDie );
+        // FIXME account for GroupCount
+        auto mask = ptr->Processor.GroupMask[0].Mask;
+        int core = 0;
+        while( mask != 0 )
+        {
+            if( mask & 1 ) cpuData[core].die = idx;
             core++;
             mask >>= 1;
         }
@@ -3838,12 +4002,26 @@ void Profiler::ReportTopology()
         fclose( f );
         cpuData[i].package = uint32_t( atoi( buf ) );
         cpuData[i].thread = i;
+
         sprintf( path, "%s%i/topology/core_id", basePath, i );
         f = fopen( path, "rb" );
-        read = fread( buf, 1, 1024, f );
-        buf[read] = '\0';
-        fclose( f );
-        cpuData[i].core = uint32_t( atoi( buf ) );
+        if( f )
+        {
+            read = fread( buf, 1, 1024, f );
+            buf[read] = '\0';
+            fclose( f );
+            cpuData[i].core = uint32_t( atoi( buf ) );
+        }
+
+        sprintf( path, "%s%i/topology/die_id", basePath, i );
+        f = fopen( path, "rb" );
+        if( f )
+        {
+            read = fread( buf, 1, 1024, f );
+            buf[read] = '\0';
+            fclose( f );
+            cpuData[i].die = uint32_t( atoi( buf ) );
+        }
     }
 
     for( int i=0; i<numcpus; i++ )
@@ -3868,7 +4046,7 @@ void Profiler::ReportTopology()
 #endif
 }
 
-void Profiler::SendCallstack( int depth, const char* skipBefore )
+void Profiler::SendCallstack( int32_t depth, const char* skipBefore )
 {
 #ifdef TRACY_HAS_CALLSTACK
     auto ptr = Callstack( depth );
@@ -3943,13 +4121,12 @@ void Profiler::HandleSymbolCodeQuery( uint64_t symbol, uint32_t size )
     }
     else
     {
-        if( !EnsureReadable( symbol ) )
-        {
-            AckSymbolCodeNotAvailable();
-            return;
-        }
+        auto&& lambda = [ this, symbol ]( const char* buf, size_t size ) {
+            SendLongString( symbol, buf, size, QueueType::SymbolCode );
+        };
 
-        SendLongString( symbol, (const char*)symbol, size, QueueType::SymbolCode );
+        // 'symbol' may have come from a module that has since unloaded, perform a safe copy before sending
+        if( !WithSafeCopy( (const char*)symbol, size, lambda ) ) AckSymbolCodeNotAvailable();
     }
 }
 
@@ -4071,7 +4248,7 @@ int64_t Profiler::GetTimeQpc()
 extern "C" {
 #endif
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4099,7 +4276,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_l
     return ctx;
 }
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int32_t depth, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4118,17 +4295,21 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___trac
         TracyQueueCommitC( zoneValidationThread );
     }
 #endif
-    tracy::GetProfiler().SendCallstack( depth );
+    auto zoneQueue = tracy::QueueType::ZoneBegin;
+    if( depth > 0 && tracy::has_callstack() )
     {
-        TracyQueuePrepareC( tracy::QueueType::ZoneBeginCallstack );
-        tracy::MemWrite( &item->zoneBegin.time, tracy::Profiler::GetTime() );
-        tracy::MemWrite( &item->zoneBegin.srcloc, (uint64_t)srcloc );
-        TracyQueueCommitC( zoneBeginThread );
+        tracy::GetProfiler().SendCallstack( depth );
+        zoneQueue = tracy::QueueType::ZoneBeginCallstack;
     }
+    TracyQueuePrepareC( zoneQueue );
+    tracy::MemWrite( &item->zoneBegin.time, tracy::Profiler::GetTime() );
+    tracy::MemWrite( &item->zoneBegin.srcloc, (uint64_t)srcloc );
+    TracyQueueCommitC( zoneBeginThread );
+
     return ctx;
 }
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4160,7 +4341,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int act
     return ctx;
 }
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int depth, int active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int32_t depth, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4183,13 +4364,17 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srclo
         TracyQueueCommitC( zoneValidationThread );
     }
 #endif
-    tracy::GetProfiler().SendCallstack( depth );
+    auto zoneQueue = tracy::QueueType::ZoneBeginAllocSrcLoc;
+    if( depth > 0 && tracy::has_callstack() )
     {
-        TracyQueuePrepareC( tracy::QueueType::ZoneBeginAllocSrcLocCallstack );
-        tracy::MemWrite( &item->zoneBegin.time, tracy::Profiler::GetTime() );
-        tracy::MemWrite( &item->zoneBegin.srcloc, srcloc );
-        TracyQueueCommitC( zoneBeginThread );
+        tracy::GetProfiler().SendCallstack( depth );
+        zoneQueue = tracy::QueueType::ZoneBeginAllocSrcLocCallstack;
     }
+    TracyQueuePrepareC( zoneQueue );
+    tracy::MemWrite( &item->zoneBegin.time, tracy::Profiler::GetTime() );
+    tracy::MemWrite( &item->zoneBegin.srcloc, srcloc );
+    TracyQueueCommitC( zoneBeginThread );
+
     return ctx;
 }
 
@@ -4287,26 +4472,78 @@ TRACY_API void ___tracy_emit_zone_value( TracyCZoneCtx ctx, uint64_t value )
     }
 }
 
-TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int secure ) { tracy::Profiler::MemAlloc( ptr, size, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int depth, int secure ) { tracy::Profiler::MemAllocCallstack( ptr, size, depth, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_free( const void* ptr, int secure ) { tracy::Profiler::MemFree( ptr, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, int secure ) { tracy::Profiler::MemFreeCallstack( ptr, depth, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int secure, const char* name ) { tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int depth, int secure, const char* name ) { tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int secure, const char* name ) { tracy::Profiler::MemFreeNamed( ptr, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int depth, int secure, const char* name ) { tracy::Profiler::MemFreeCallstackNamed( ptr, depth, secure != 0, name ); }
+TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int32_t secure ) { tracy::Profiler::MemAlloc( ptr, size, secure != 0 ); }
+TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int32_t depth, int32_t secure )
+{
+    if( depth > 0 && tracy::has_callstack() )
+    {
+        tracy::Profiler::MemAllocCallstack( ptr, size, depth, secure != 0 );
+    }
+    else
+    {
+        tracy::Profiler::MemAlloc( ptr, size, secure != 0 );
+    }
+}
+TRACY_API void ___tracy_emit_memory_free( const void* ptr, int32_t secure ) { tracy::Profiler::MemFree( ptr, secure != 0 ); }
+TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int32_t depth, int32_t secure )
+{
+    if( depth > 0 && tracy::has_callstack() )
+    {
+        tracy::Profiler::MemFreeCallstack( ptr, depth, secure != 0 );
+    }
+    else
+    {
+        tracy::Profiler::MemFree( ptr, secure != 0 );
+    }
+}
+TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure ) { tracy::Profiler::MemDiscard( name, secure != 0 ); }
+TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int32_t depth )
+{
+    if( depth > 0 && tracy::has_callstack() )
+    {
+        tracy::Profiler::MemDiscardCallstack( name, secure != 0, depth );
+    }
+    else
+    {
+        tracy::Profiler::MemDiscard( name, secure != 0 );
+    }
+}
+TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int32_t secure, const char* name ) { tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name ); }
+TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int32_t depth, int32_t secure, const char* name )
+{
+    if( depth > 0 && tracy::has_callstack() )
+    {
+        tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, secure != 0, name );
+    }
+    else
+    {
+        tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name );
+    }
+}
+TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int32_t secure, const char* name ) { tracy::Profiler::MemFreeNamed( ptr, secure != 0, name ); }
+TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32_t depth, int32_t secure, const char* name )
+{
+    if( depth > 0 && tracy::has_callstack() )
+    {
+        tracy::Profiler::MemFreeCallstackNamed( ptr, depth, secure != 0, name );
+    }
+    else
+    {
+        tracy::Profiler::MemFreeNamed( ptr, secure != 0, name );
+    }
+}
 TRACY_API void ___tracy_emit_frame_mark( const char* name ) { tracy::Profiler::SendFrameMark( name ); }
 TRACY_API void ___tracy_emit_frame_mark_start( const char* name ) { tracy::Profiler::SendFrameMark( name, tracy::QueueType::FrameMarkMsgStart ); }
 TRACY_API void ___tracy_emit_frame_mark_end( const char* name ) { tracy::Profiler::SendFrameMark( name, tracy::QueueType::FrameMarkMsgEnd ); }
-TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_t h, uint8_t offset, int flip ) { tracy::Profiler::SendFrameImage( image, w, h, offset, flip ); }
+TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_t h, uint8_t offset, int32_t flip ) { tracy::Profiler::SendFrameImage( image, w, h, offset, flip != 0 ); }
 TRACY_API void ___tracy_emit_plot( const char* name, double val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_float( const char* name, float val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_int( const char* name, int64_t val ) { tracy::Profiler::PlotData( name, val ); }
-TRACY_API void ___tracy_emit_plot_config( const char* name, int type, int step, int fill, uint32_t color ) { tracy::Profiler::ConfigurePlot( name, tracy::PlotFormatType(type), step, fill, color ); }
-TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int callstack ) { tracy::Profiler::Message( txt, size, callstack ); }
-TRACY_API void ___tracy_emit_messageL( const char* txt, int callstack ) { tracy::Profiler::Message( txt, callstack ); }
-TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int callstack ) { tracy::Profiler::MessageColor( txt, size, color, callstack ); }
-TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int callstack ) { tracy::Profiler::MessageColor( txt, color, callstack ); }
+TRACY_API void ___tracy_emit_plot_config( const char* name, int32_t type, int32_t step, int32_t fill, uint32_t color ) { tracy::Profiler::ConfigurePlot( name, tracy::PlotFormatType(type), step != 0, fill != 0, color ); }
+TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int32_t callstack_depth ) { tracy::Profiler::Message( txt, size, callstack_depth ); }
+TRACY_API void ___tracy_emit_messageL( const char* txt, int32_t callstack_depth ) { tracy::Profiler::Message( txt, callstack_depth ); }
+TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int32_t callstack_depth ) { tracy::Profiler::MessageColor( txt, size, color, callstack_depth ); }
+TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int32_t callstack_depth ) { tracy::Profiler::MessageColor( txt, color, callstack_depth ); }
 TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size ) { tracy::Profiler::MessageAppInfo( txt, size ); }
 
 TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, uint32_t color ) {
@@ -4604,7 +4841,7 @@ TRACY_API void ___tracy_terminate_lockable_ctx( struct __tracy_lockable_context_
     tracy::tracy_free((void*)lockdata);
 }
 
-TRACY_API int ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata )
+TRACY_API int32_t ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata )
 {
 #ifdef TRACY_ON_DEMAND
     bool queue = false;
@@ -4616,7 +4853,7 @@ TRACY_API int ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context
         if( active != connected ) lockdata->m_active.store( connected, std::memory_order_relaxed );
         if( connected ) queue = true;
     }
-    if( !queue ) return false;
+    if( !queue ) return static_cast<int32_t>(false);
 #endif
 
     auto item = tracy::Profiler::QueueSerial();
@@ -4625,7 +4862,7 @@ TRACY_API int ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context
     tracy::MemWrite( &item->lockWait.id, lockdata->m_id );
     tracy::MemWrite( &item->lockWait.time, tracy::Profiler::GetTime() );
     tracy::Profiler::QueueSerialFinish();
-    return true;
+    return static_cast<int32_t>(true);
 }
 
 TRACY_API void ___tracy_after_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata )
@@ -4657,7 +4894,7 @@ TRACY_API void ___tracy_after_unlock_lockable_ctx( struct __tracy_lockable_conte
     tracy::Profiler::QueueSerialFinish();
 }
 
-TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int acquired )
+TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int32_t acquired )
 {
 #ifdef TRACY_ON_DEMAND
     if( !acquired ) return;
@@ -4722,9 +4959,9 @@ TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_contex
     tracy::Profiler::QueueSerialFinish();
 }
 
-TRACY_API int ___tracy_connected( void )
+TRACY_API int32_t ___tracy_connected( void )
 {
-    return tracy::GetProfiler().IsConnected();
+    return static_cast<int32_t>( tracy::GetProfiler().IsConnected() );
 }
 
 #ifdef TRACY_FIBERS
@@ -4732,7 +4969,7 @@ TRACY_API void ___tracy_fiber_enter( const char* fiber ){ tracy::Profiler::Enter
 TRACY_API void ___tracy_fiber_leave( void ){ tracy::Profiler::LeaveFiber(); }
 #endif
 
-#  ifdef TRACY_MANUAL_LIFETIME
+#  if defined TRACY_MANUAL_LIFETIME && defined TRACY_DELAYED_INIT
 TRACY_API void ___tracy_startup_profiler( void )
 {
     tracy::StartupProfiler();
@@ -4743,9 +4980,9 @@ TRACY_API void ___tracy_shutdown_profiler( void )
     tracy::ShutdownProfiler();
 }
 
-TRACY_API int ___tracy_profiler_started( void )
+TRACY_API int32_t ___tracy_profiler_started( void )
 {
-    return tracy::s_isProfilerStarted.load( std::memory_order_seq_cst );
+    return static_cast<int32_t>( tracy::s_isProfilerStarted.load( std::memory_order_seq_cst ) );
 }
 #  endif
 

--- a/tracy-client-sys/tracy/client/TracyScoped.hpp
+++ b/tracy-client-sys/tracy/client/TracyScoped.hpp
@@ -10,6 +10,7 @@
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyAlloc.hpp"
 #include "TracyProfiler.hpp"
+#include "TracyCallstack.hpp"
 
 namespace tracy
 {
@@ -22,7 +23,7 @@ public:
     ScopedZone& operator=( const ScopedZone& ) = delete;
     ScopedZone& operator=( ScopedZone&& ) = delete;
 
-    tracy_force_inline ScopedZone( const SourceLocationData* srcloc, bool is_active = true )
+    tracy_force_inline ScopedZone( const SourceLocationData* srcloc, int32_t depth = -1, bool is_active = true )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else
@@ -33,13 +34,19 @@ public:
 #ifdef TRACY_ON_DEMAND
         m_connectionId = GetProfiler().ConnectionId();
 #endif
-        TracyQueuePrepare( QueueType::ZoneBegin );
+        auto zoneQueue = QueueType::ZoneBegin;
+        if( depth > 0 && has_callstack() )
+        {
+            GetProfiler().SendCallstack( depth );
+            zoneQueue = QueueType::ZoneBeginCallstack;
+        }
+        TracyQueuePrepare( zoneQueue );
         MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
         MemWrite( &item->zoneBegin.srcloc, (uint64_t)srcloc );
         TracyQueueCommit( zoneBeginThread );
     }
 
-    tracy_force_inline ScopedZone( const SourceLocationData* srcloc, int depth, bool is_active = true )
+    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color, int32_t depth = -1, bool is_active = true )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else
@@ -50,55 +57,21 @@ public:
 #ifdef TRACY_ON_DEMAND
         m_connectionId = GetProfiler().ConnectionId();
 #endif
-        GetProfiler().SendCallstack( depth );
-
-        TracyQueuePrepare( QueueType::ZoneBeginCallstack );
-        MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
-        MemWrite( &item->zoneBegin.srcloc, (uint64_t)srcloc );
-        TracyQueueCommit( zoneBeginThread );
-    }
-
-    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color, bool is_active = true )
-#ifdef TRACY_ON_DEMAND
-        : m_active( is_active && GetProfiler().IsConnected() )
-#else
-        : m_active( is_active )
-#endif
-    {
-        if( !m_active ) return;
-#ifdef TRACY_ON_DEMAND
-        m_connectionId = GetProfiler().ConnectionId();
-#endif
-        TracyQueuePrepare( QueueType::ZoneBeginAllocSrcLoc );
-        const auto srcloc = Profiler::AllocSourceLocation( line, source, sourceSz, function, functionSz, name, nameSz, color );
+        auto zoneQueue = QueueType::ZoneBeginAllocSrcLoc;
+        if( depth > 0 && has_callstack() )
+        {
+            GetProfiler().SendCallstack( depth );
+            zoneQueue = QueueType::ZoneBeginAllocSrcLocCallstack;
+        }
+        TracyQueuePrepare( zoneQueue );
+        const auto srcloc =
+            Profiler::AllocSourceLocation( line, source, sourceSz, function, functionSz, name, nameSz, color );
         MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
         MemWrite( &item->zoneBegin.srcloc, srcloc );
         TracyQueueCommit( zoneBeginThread );
     }
 
-    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, bool is_active = true ) : ScopedZone( line, source, sourceSz, function, functionSz, name, nameSz, static_cast<uint32_t>(0), is_active ) {}
-
-    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color, int depth, bool is_active = true )
-#ifdef TRACY_ON_DEMAND
-        : m_active( is_active && GetProfiler().IsConnected() )
-#else
-        : m_active( is_active )
-#endif
-    {
-        if( !m_active ) return;
-#ifdef TRACY_ON_DEMAND
-        m_connectionId = GetProfiler().ConnectionId();
-#endif
-        GetProfiler().SendCallstack( depth );
-
-        TracyQueuePrepare( QueueType::ZoneBeginAllocSrcLocCallstack );
-        const auto srcloc = Profiler::AllocSourceLocation( line, source, sourceSz, function, functionSz, name, nameSz, color );
-        MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
-        MemWrite( &item->zoneBegin.srcloc, srcloc );
-        TracyQueueCommit( zoneBeginThread );
-    }
-
-    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool is_active = true ) : ScopedZone( line, source, sourceSz, function, functionSz, name, nameSz, 0, depth, is_active ) {}
+    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool is_active = true ) : ScopedZone( line, source, sourceSz, function, functionSz, name, nameSz, 0, depth, is_active ) {}
 
     tracy_force_inline ~ScopedZone()
     {

--- a/tracy-client-sys/tracy/client/TracySysPower.cpp
+++ b/tracy-client-sys/tracy/client/TracySysPower.cpp
@@ -85,7 +85,7 @@ void SysPower::ScanDirectory( const char* path, int parent )
                 FILE* f = fopen( tmp, "r" );
                 if( f )
                 {
-                    fscanf( f, "%" PRIu64, &maxRange );
+                    (void)fscanf( f, "%" PRIu64, &maxRange );
                     fclose( f );
                 }
             }

--- a/tracy-client-sys/tracy/client/TracySysTrace.cpp
+++ b/tracy-client-sys/tracy/client/TracySysTrace.cpp
@@ -173,8 +173,11 @@ void WINAPI EventRecordCallback( PEVENT_RECORD record )
             MemWrite( &item->contextSwitch.oldThread, cswitch->oldThreadId );
             MemWrite( &item->contextSwitch.newThread, cswitch->newThreadId );
             MemWrite( &item->contextSwitch.cpu, record->BufferContext.ProcessorNumber );
-            MemWrite( &item->contextSwitch.reason, cswitch->oldThreadWaitReason );
-            MemWrite( &item->contextSwitch.state, cswitch->oldThreadState );
+            MemWrite( &item->contextSwitch.oldThreadWaitReason, cswitch->oldThreadWaitReason );
+            MemWrite( &item->contextSwitch.oldThreadState, cswitch->oldThreadState );
+            MemWrite( &item->contextSwitch.newThreadPriority, cswitch->newThreadPriority );
+            MemWrite( &item->contextSwitch.oldThreadPriority, cswitch->oldThreadPriority );
+            MemWrite( &item->contextSwitch.previousCState, cswitch->previousCState );
             TracyLfqCommit;
         }
         else if( hdr.EventDescriptor.Opcode == 50 )
@@ -183,7 +186,10 @@ void WINAPI EventRecordCallback( PEVENT_RECORD record )
 
             TracyLfqPrepare( QueueType::ThreadWakeup );
             MemWrite( &item->threadWakeup.time, hdr.TimeStamp.QuadPart );
+            MemWrite( &item->threadWakeup.cpu, record->BufferContext.ProcessorNumber );
             MemWrite( &item->threadWakeup.thread, rt->threadId );
+            MemWrite( &item->threadWakeup.adjustReason, rt->adjustReason );
+            MemWrite( &item->threadWakeup.adjustIncrement, rt->adjustIncrement );
             TracyLfqCommit;
         }
         else if( hdr.EventDescriptor.Opcode == 1 || hdr.EventDescriptor.Opcode == 3 )
@@ -498,11 +504,11 @@ void SysTraceGetExternalName( uint64_t thread, const char*& threadName, const ch
         if( _GetThreadDescription )
         {
             PWSTR tmp;
-            _GetThreadDescription( hnd, &tmp );
-            char buf[256];
-            if( tmp )
+            if ( SUCCEEDED( _GetThreadDescription( hnd, &tmp ) ) )
             {
+                char buf[256];
                 auto ret = wcstombs( buf, tmp, 256 );
+                LocalFree(tmp);
                 if( ret != 0 )
                 {
                     threadName = CopyString( buf, ret );
@@ -678,7 +684,7 @@ enum TraceEventId
     EventBranchMiss,
     EventVsync,
     EventContextSwitch,
-    EventWakeup,
+    EventWaking,
 };
 
 static void ProbePreciseIp( perf_event_attr& pe, unsigned long long config0, unsigned long long config1, pid_t pid )
@@ -767,16 +773,16 @@ bool SysTraceStart( int64_t& samplingPeriod )
     TracyDebug( "perf_event_paranoid: %i\n", paranoidLevel );
 #endif
 
-    int switchId = -1, wakeupId = -1, vsyncId = -1;
+    int switchId = -1, wakingId = -1, vsyncId = -1;
     const auto switchIdStr = ReadFile( "/sys/kernel/debug/tracing/events/sched/sched_switch/id" );
     if( switchIdStr ) switchId = atoi( switchIdStr );
-    const auto wakeupIdStr = ReadFile( "/sys/kernel/debug/tracing/events/sched/sched_wakeup/id" );
-    if( wakeupIdStr ) wakeupId = atoi( wakeupIdStr );
+    const auto wakingIdStr = ReadFile( "/sys/kernel/debug/tracing/events/sched/sched_waking/id" );
+    if( wakingIdStr ) wakingId = atoi( wakingIdStr );
     const auto vsyncIdStr = ReadFile( "/sys/kernel/debug/tracing/events/drm/drm_vblank_event/id" );
     if( vsyncIdStr ) vsyncId = atoi( vsyncIdStr );
 
     TracyDebug( "sched_switch id: %i\n", switchId );
-    TracyDebug( "sched_wakeup id: %i\n", wakeupId );
+    TracyDebug( "sched_waking id: %i\n", wakingId );
     TracyDebug( "drm_vblank_event id: %i\n", vsyncId );
 
 #ifdef TRACY_NO_SAMPLING
@@ -831,7 +837,7 @@ bool SysTraceStart( int64_t& samplingPeriod )
         2 +     // CPU cycles + instructions retired
         2 +     // cache reference + miss
         2 +     // branch retired + miss
-        2 +     // context switches + wakeups
+        2 +     // context switches + waking ups
         1       // vsync
     );
     s_ring = (RingBuffer*)tracy_malloc( sizeof( RingBuffer ) * maxNumBuffers );
@@ -1076,18 +1082,31 @@ bool SysTraceStart( int64_t& samplingPeriod )
             }
         }
 
-        if( wakeupId != -1 )
+        if( wakingId != -1 )
         {
-            pe.config = wakeupId;
-            pe.config &= ~PERF_SAMPLE_CALLCHAIN;
+            pe = {};
+            pe.type = PERF_TYPE_TRACEPOINT;
+            pe.size = sizeof( perf_event_attr );
+            pe.sample_period = 1;
+            pe.sample_type = PERF_SAMPLE_TIME | PERF_SAMPLE_RAW;
+            // Coult ask for callstack here
+            //pe.sample_type |= PERF_SAMPLE_CALLCHAIN;
+            pe.disabled = 1;
+            pe.inherit = 1;
+            pe.config = wakingId;
+            pe.read_format = 0;
+#if !defined TRACY_HW_TIMER || !( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
+            pe.use_clockid = 1;
+            pe.clockid = CLOCK_MONOTONIC_RAW;
+#endif
 
-            TracyDebug( "Setup wakeup capture\n" );
+            TracyDebug( "Setup waking up capture\n" );
             for( int i=0; i<s_numCpus; i++ )
             {
                 const int fd = perf_event_open( &pe, -1, i, -1, PERF_FLAG_FD_CLOEXEC );
                 if( fd != -1 )
                 {
-                    new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventWakeup, i );
+                    new( s_ring+s_numBuffers ) RingBuffer( 64*1024, fd, EventWaking, i );
                     if( s_ring[s_numBuffers].IsValid() )
                     {
                         s_numBuffers++;
@@ -1332,6 +1351,7 @@ void SysTraceWorker( void* ptr )
                 hadData = true;
                 while( activeNum > 0 )
                 {
+                    // Find the earliest event from the active buffers
                     int sel = -1;
                     int selPos;
                     int64_t t0 = std::numeric_limits<int64_t>::max();
@@ -1369,6 +1389,7 @@ void SysTraceWorker( void* ptr )
                             }
                         }
                     }
+                    // Found any event
                     if( sel >= 0 )
                     {
                         auto& ring = ringArray[ctxBufferIdx + sel];
@@ -1384,10 +1405,10 @@ void SysTraceWorker( void* ptr )
                         const auto rid = ring.GetId();
                         if( rid == EventContextSwitch )
                         {
-                            // Layout:
-                            //   u64 time
-                            //   u64 cnt
-                            //   u64 ip[cnt]
+                            // Layout: See /sys/kernel/debug/tracing/events/sched/sched_switch/format
+                            //   u64 time    // PERF_SAMPLE_TIME
+                            //   u64 cnt     // PERF_SAMPLE_CALLCHAIN
+                            //   u64 ip[cnt] // PERF_SAMPLE_CALLCHAIN
                             //   u32 size
                             //   u8  data[size]
                             // Data (not ABI stable, but has not changed since it was added, in 2009):
@@ -1408,35 +1429,43 @@ void SysTraceWorker( void* ptr )
                             const auto traceOffset = offset;
                             offset += sizeof( uint64_t ) * cnt + sizeof( uint32_t ) + 8 + 16;
 
-                            uint32_t prev_pid, next_pid;
+                            uint32_t prev_pid, prev_prio;
+                            uint32_t next_pid, next_prio;
                             long prev_state;
 
                             ring.Read( &prev_pid, offset, sizeof( uint32_t ) );
-                            offset += sizeof( uint32_t ) + sizeof( uint32_t );
+                            offset += sizeof( uint32_t );
+                            ring.Read( &prev_prio, offset, sizeof( uint32_t ) );
+                            offset += sizeof( uint32_t );
                             ring.Read( &prev_state, offset, sizeof( long ) );
                             offset += sizeof( long ) + 16;
                             ring.Read( &next_pid, offset, sizeof( uint32_t ) );
+                            offset += sizeof( uint32_t );
+                            ring.Read( &next_prio, offset, sizeof( uint32_t ) );
 
-                            uint8_t reason = 100;
-                            uint8_t state;
+                            uint8_t oldThreadWaitReason = 100;
+                            uint8_t oldThreadState;
 
-                            if(      prev_state & 0x0001 ) state = 104;
-                            else if( prev_state & 0x0002 ) state = 101;
-                            else if( prev_state & 0x0004 ) state = 105;
-                            else if( prev_state & 0x0008 ) state = 106;
-                            else if( prev_state & 0x0010 ) state = 108;
-                            else if( prev_state & 0x0020 ) state = 109;
-                            else if( prev_state & 0x0040 ) state = 110;
-                            else if( prev_state & 0x0080 ) state = 102;
-                            else                           state = 103;
+                            if(      prev_state & 0x0001 ) oldThreadState = 104;
+                            else if( prev_state & 0x0002 ) oldThreadState = 101;
+                            else if( prev_state & 0x0004 ) oldThreadState = 105;
+                            else if( prev_state & 0x0008 ) oldThreadState = 106;
+                            else if( prev_state & 0x0010 ) oldThreadState = 108;
+                            else if( prev_state & 0x0020 ) oldThreadState = 109;
+                            else if( prev_state & 0x0040 ) oldThreadState = 110;
+                            else if( prev_state & 0x0080 ) oldThreadState = 102;
+                            else                           oldThreadState = 103;
 
                             TracyLfqPrepare( QueueType::ContextSwitch );
                             MemWrite( &item->contextSwitch.time, t0 );
                             MemWrite( &item->contextSwitch.oldThread, prev_pid );
                             MemWrite( &item->contextSwitch.newThread, next_pid );
                             MemWrite( &item->contextSwitch.cpu, uint8_t( ring.GetCpu() ) );
-                            MemWrite( &item->contextSwitch.reason, reason );
-                            MemWrite( &item->contextSwitch.state, state );
+                            MemWrite( &item->contextSwitch.oldThreadWaitReason, oldThreadWaitReason );
+                            MemWrite( &item->contextSwitch.oldThreadState, oldThreadState );
+                            MemWrite( &item->contextSwitch.previousCState, uint8_t( 0 ) );
+                            MemWrite( &item->contextSwitch.newThreadPriority, int8_t( next_prio ) );
+                            MemWrite( &item->contextSwitch.oldThreadPriority, int8_t( prev_prio ) );
                             TracyLfqCommit;
 
                             if( cnt > 0 && prev_pid != 0 && CurrentProcOwnsThread( prev_pid ) )
@@ -1450,27 +1479,33 @@ void SysTraceWorker( void* ptr )
                                 TracyLfqCommit;
                             }
                         }
-                        else if( rid == EventWakeup )
+                        else if( rid == EventWaking)
                         {
+                            // See /sys/kernel/debug/tracing/events/sched/sched_waking/format
                             // Layout:
-                            //   u64 time
+                            //   u64 time // PERF_SAMPLE_TIME
                             //   u32 size
                             //   u8  data[size]
                             // Data:
                             //   u8  hdr[8]
                             //   u8  comm[16]
                             //   u32 pid
-                            //   u32 prio
-                            //   u64 target_cpu
-
-                            offset += sizeof( perf_event_header ) + sizeof( uint64_t ) + sizeof( uint32_t ) + 8 + 16;
-
+                            //   i32 prio
+                            //   i32 target_cpu
+                            const uint32_t dataOffset = sizeof( perf_event_header ) + sizeof( uint64_t ) + sizeof( uint32_t ); 
+                            offset += dataOffset + 8 + 16;
                             uint32_t pid;
                             ring.Read( &pid, offset, sizeof( uint32_t ) );
-
+                            
                             TracyLfqPrepare( QueueType::ThreadWakeup );
                             MemWrite( &item->threadWakeup.time, t0 );
                             MemWrite( &item->threadWakeup.thread, pid );
+                            MemWrite( &item->threadWakeup.cpu, (uint8_t)ring.GetCpu() );
+
+                            int8_t adjustReason = -1; // Does not exist on Linux
+                            int8_t adjustIncrement = 0; // Should perhaps store the new prio?
+                            MemWrite( &item->threadWakeup.adjustReason, adjustReason );
+                            MemWrite( &item->threadWakeup.adjustIncrement, adjustIncrement );
                             TracyLfqCommit;
                         }
                         else

--- a/tracy-client-sys/tracy/client/tracy_rpmalloc.cpp
+++ b/tracy-client-sys/tracy/client/tracy_rpmalloc.cpp
@@ -690,7 +690,9 @@ static pthread_key_t _memory_thread_heap;
 #    define _Thread_local __declspec(thread)
 #    define TLS_MODEL
 #  else
-#    ifndef __HAIKU__
+#    if defined(__ANDROID__) && __ANDROID_API__ >= 29 && defined(__NDK_MAJOR__) && __NDK_MAJOR__ >= 26
+#      define TLS_MODEL __attribute__((tls_model("local-dynamic")))
+#    elif !defined(__HAIKU__)
 #      define TLS_MODEL __attribute__((tls_model("initial-exec")))
 #    else
 #      define TLS_MODEL

--- a/tracy-client-sys/tracy/common/TracyProtocol.hpp
+++ b/tracy-client-sys/tracy/common/TracyProtocol.hpp
@@ -9,7 +9,7 @@ namespace tracy
 
 constexpr unsigned Lz4CompressBound( unsigned isize ) { return isize + ( isize / 255 ) + 16; }
 
-enum : uint32_t { ProtocolVersion = 69 };
+enum : uint32_t { ProtocolVersion = 74 };
 enum : uint16_t { BroadcastVersion = 3 };
 
 using lz4sz_t = uint32_t;

--- a/tracy-client-sys/tracy/common/TracyQueue.hpp
+++ b/tracy-client-sys/tracy/common/TracyQueue.hpp
@@ -42,6 +42,8 @@ enum class QueueType : uint8_t
     MemAllocCallstackNamed,
     MemFreeCallstack,
     MemFreeCallstackNamed,
+    MemDiscard,
+    MemDiscardCallstack,
     GpuZoneBegin,
     GpuZoneBeginCallstack,
     GpuZoneBeginAllocSrcLoc,
@@ -401,7 +403,10 @@ enum class GpuContextType : uint8_t
     Vulkan,
     OpenCL,
     Direct3D12,
-    Direct3D11
+    Direct3D11,
+    Metal,
+    Custom,
+    CUDA
 };
 
 enum GpuContextFlags : uint8_t
@@ -500,6 +505,13 @@ struct QueueMemFree
     uint64_t ptr;
 };
 
+struct QueueMemDiscard
+{
+    int64_t time;
+    uint32_t thread;
+    uint64_t name;
+};
+
 struct QueueCallstackFat
 {
     uint64_t ptr;
@@ -593,14 +605,20 @@ struct QueueContextSwitch
     uint32_t oldThread;
     uint32_t newThread;
     uint8_t cpu;
-    uint8_t reason;
-    uint8_t state;
+    uint8_t oldThreadWaitReason;
+    uint8_t oldThreadState;
+    uint8_t previousCState;
+    int8_t newThreadPriority;
+    int8_t oldThreadPriority;
 };
 
 struct QueueThreadWakeup
 {
     int64_t time;
     uint32_t thread;
+    uint8_t cpu;
+    int8_t adjustReason;
+    int8_t adjustIncrement;
 };
 
 struct QueueTidToPid
@@ -740,6 +758,7 @@ struct QueueItem
         QueueGpuContextNameFat gpuContextNameFat;
         QueueMemAlloc memAlloc;
         QueueMemFree memFree;
+        QueueMemDiscard memDiscard;
         QueueMemNamePayload memName;
         QueueThreadGroupHint threadGroupHint;
         QueueCallstackFat callstackFat;
@@ -811,6 +830,8 @@ static constexpr size_t QueueDataSize[] = {
     sizeof( QueueHeader ) + sizeof( QueueMemAlloc ),        // callstack, named
     sizeof( QueueHeader ) + sizeof( QueueMemFree ),         // callstack
     sizeof( QueueHeader ) + sizeof( QueueMemFree ),         // callstack, named
+    sizeof( QueueHeader ) + sizeof( QueueMemDiscard ),
+    sizeof( QueueHeader ) + sizeof( QueueMemDiscard ),      // callstack
     sizeof( QueueHeader ) + sizeof( QueueGpuZoneBegin ),
     sizeof( QueueHeader ) + sizeof( QueueGpuZoneBegin ),    // callstack
     sizeof( QueueHeader ) + sizeof( QueueGpuZoneBeginLean ),// allocated source location

--- a/tracy-client-sys/tracy/common/TracySystem.cpp
+++ b/tracy-client-sys/tracy/common/TracySystem.cpp
@@ -26,7 +26,9 @@
 #  include <fcntl.h>
 #elif defined __FreeBSD__
 #  include <sys/thr.h>
-#elif defined __NetBSD__ || defined __DragonFly__
+#elif defined __NetBSD__
+#  include <lwp.h>
+#elif defined __DragonFly__
 #  include <sys/lwp.h>
 #elif defined __QNX__
 #  include <process.h>

--- a/tracy-client-sys/tracy/common/TracyVersion.hpp
+++ b/tracy-client-sys/tracy/common/TracyVersion.hpp
@@ -6,8 +6,8 @@ namespace tracy
 namespace Version
 {
 enum { Major = 0 };
-enum { Minor = 11 };
-enum { Patch = 1 };
+enum { Minor = 12 };
+enum { Patch = 0 };
 }
 }
 

--- a/tracy-client-sys/tracy/libbacktrace/dwarf.cpp
+++ b/tracy-client-sys/tracy/libbacktrace/dwarf.cpp
@@ -725,8 +725,8 @@ struct dwarf_data
   struct dwarf_data *next;
   /* The data for .gnu_debugaltlink.  */
   struct dwarf_data *altlink;
-  /* The base address for this file.  */
-  uintptr_t base_address;
+/* The base address mapping for this file.  */
+  struct libbacktrace_base_address base_address;
   /* A sorted list of address ranges.  */
   struct unit_addrs *addrs;
   /* Number of address ranges in list.  */
@@ -1947,8 +1947,9 @@ update_pcrange (const struct attr* attr, const struct attr_val* val,
 static int
 add_low_high_range (struct backtrace_state *state,
 		    const struct dwarf_sections *dwarf_sections,
-		    uintptr_t base_address, int is_bigendian,
-		    struct unit *u, const struct pcrange *pcrange,
+		    struct libbacktrace_base_address base_address,
+		    int is_bigendian, struct unit *u,
+		    const struct pcrange *pcrange,
 		    int (*add_range) (struct backtrace_state *state,
 				      void *rdata, uintptr_t lowpc,
 				      uintptr_t highpc,
@@ -1983,8 +1984,8 @@ add_low_high_range (struct backtrace_state *state,
 
   /* Add in the base address of the module when recording PC values,
      so that we can look up the PC directly.  */
-  lowpc += base_address;
-  highpc += base_address;
+  lowpc = libbacktrace_add_base (lowpc, base_address);
+  highpc = libbacktrace_add_base (highpc, base_address);
 
   return add_range (state, rdata, lowpc, highpc, error_callback, data, vec);
 }
@@ -1996,7 +1997,7 @@ static int
 add_ranges_from_ranges (
     struct backtrace_state *state,
     const struct dwarf_sections *dwarf_sections,
-    uintptr_t base_address, int is_bigendian,
+    struct libbacktrace_base_address base_address, int is_bigendian,
     struct unit *u, uintptr_t base,
     const struct pcrange *pcrange,
     int (*add_range) (struct backtrace_state *state, void *rdata,
@@ -2042,10 +2043,11 @@ add_ranges_from_ranges (
 	base = (uintptr_t) high;
       else
 	{
-	  if (!add_range (state, rdata, 
-			  (uintptr_t) low + base + base_address,
-			  (uintptr_t) high + base + base_address,
-			  error_callback, data, vec))
+	  uintptr_t rl, rh;
+
+	  rl = libbacktrace_add_base ((uintptr_t) low + base, base_address);
+	  rh = libbacktrace_add_base ((uintptr_t) high + base, base_address);
+	  if (!add_range (state, rdata, rl, rh, error_callback, data, vec))
 	    return 0;
 	}
     }
@@ -2063,7 +2065,7 @@ static int
 add_ranges_from_rnglists (
     struct backtrace_state *state,
     const struct dwarf_sections *dwarf_sections,
-    uintptr_t base_address, int is_bigendian,
+    struct libbacktrace_base_address base_address, int is_bigendian,
     struct unit *u, uintptr_t base,
     const struct pcrange *pcrange,
     int (*add_range) (struct backtrace_state *state, void *rdata,
@@ -2146,9 +2148,10 @@ add_ranges_from_rnglists (
 				     u->addrsize, is_bigendian, index,
 				     error_callback, data, &high))
 	      return 0;
-	    if (!add_range (state, rdata, low + base_address,
-			    high + base_address, error_callback, data,
-			    vec))
+	    if (!add_range (state, rdata,
+			    libbacktrace_add_base (low, base_address),
+			    libbacktrace_add_base (high, base_address),
+			    error_callback, data, vec))
 	      return 0;
 	  }
 	  break;
@@ -2165,7 +2168,7 @@ add_ranges_from_rnglists (
 				     error_callback, data, &low))
 	      return 0;
 	    length = read_uleb128 (&rnglists_buf);
-	    low += base_address;
+	    low = libbacktrace_add_base (low, base_address);
 	    if (!add_range (state, rdata, low, low + length,
 			    error_callback, data, vec))
 	      return 0;
@@ -2179,8 +2182,9 @@ add_ranges_from_rnglists (
 
 	    low = read_uleb128 (&rnglists_buf);
 	    high = read_uleb128 (&rnglists_buf);
-	    if (!add_range (state, rdata, low + base + base_address,
-			    high + base + base_address,
+	    if (!add_range (state, rdata,
+			    libbacktrace_add_base (low + base, base_address),
+			    libbacktrace_add_base (high + base, base_address),
 			    error_callback, data, vec))
 	      return 0;
 	  }
@@ -2197,9 +2201,10 @@ add_ranges_from_rnglists (
 
 	    low = (uintptr_t) read_address (&rnglists_buf, u->addrsize);
 	    high = (uintptr_t) read_address (&rnglists_buf, u->addrsize);
-	    if (!add_range (state, rdata, low + base_address,
-			    high + base_address, error_callback, data,
-			    vec))
+	    if (!add_range (state, rdata,
+			    libbacktrace_add_base (low, base_address),
+			    libbacktrace_add_base (high, base_address),
+			    error_callback, data, vec))
 	      return 0;
 	  }
 	  break;
@@ -2211,7 +2216,7 @@ add_ranges_from_rnglists (
 
 	    low = (uintptr_t) read_address (&rnglists_buf, u->addrsize);
 	    length = (uintptr_t) read_uleb128 (&rnglists_buf);
-	    low += base_address;
+	    low = libbacktrace_add_base (low, base_address);
 	    if (!add_range (state, rdata, low, low + length,
 			    error_callback, data, vec))
 	      return 0;
@@ -2239,7 +2244,7 @@ add_ranges_from_rnglists (
 static int
 add_ranges (struct backtrace_state *state,
 	    const struct dwarf_sections *dwarf_sections,
-	    uintptr_t base_address, int is_bigendian,
+	    struct libbacktrace_base_address base_address, int is_bigendian,
 	    struct unit *u, uintptr_t base, const struct pcrange *pcrange,
 	    int (*add_range) (struct backtrace_state *state, void *rdata, 
 			      uintptr_t lowpc, uintptr_t highpc,
@@ -2275,7 +2280,8 @@ add_ranges (struct backtrace_state *state,
    read, 0 if there is some error.  */
 
 static int
-find_address_ranges (struct backtrace_state *state, uintptr_t base_address,
+find_address_ranges (struct backtrace_state *state,
+		     struct libbacktrace_base_address base_address,
 		     struct dwarf_buf *unit_buf,
 		     const struct dwarf_sections *dwarf_sections,
 		     int is_bigendian, struct dwarf_data *altlink,
@@ -2430,7 +2436,8 @@ find_address_ranges (struct backtrace_state *state, uintptr_t base_address,
    on success, 0 on failure.  */
 
 static int
-build_address_map (struct backtrace_state *state, uintptr_t base_address,
+build_address_map (struct backtrace_state *state,
+		   struct libbacktrace_base_address base_address,
 		   const struct dwarf_sections *dwarf_sections,
 		   int is_bigendian, struct dwarf_data *altlink,
 		   backtrace_error_callback error_callback, void *data,
@@ -2649,7 +2656,7 @@ add_line (struct backtrace_state *state, struct dwarf_data *ddata,
 
   /* Add in the base address here, so that we can look up the PC
      directly.  */
-  ln->pc = pc + ddata->base_address;
+  ln->pc = libbacktrace_add_base (pc, ddata->base_address);
 
   ln->filename = filename;
   ln->lineno = lineno;
@@ -4329,7 +4336,7 @@ dwarf_fileline (struct backtrace_state *state, uintptr_t pc,
 
 static struct dwarf_data *
 build_dwarf_data (struct backtrace_state *state,
-		  uintptr_t base_address,
+		  struct libbacktrace_base_address base_address,
 		  const struct dwarf_sections *dwarf_sections,
 		  int is_bigendian,
 		  struct dwarf_data *altlink,
@@ -4387,7 +4394,7 @@ build_dwarf_data (struct backtrace_state *state,
 
 int
 backtrace_dwarf_add (struct backtrace_state *state,
-		     uintptr_t base_address,
+		     struct libbacktrace_base_address base_address,
 		     const struct dwarf_sections *dwarf_sections,
 		     int is_bigendian,
 		     struct dwarf_data *fileline_altlink,

--- a/tracy-client-sys/tracy/libbacktrace/internal.hpp
+++ b/tracy-client-sys/tracy/libbacktrace/internal.hpp
@@ -333,10 +333,44 @@ struct dwarf_sections
 
 struct dwarf_data;
 
+/* The load address mapping.  */
+
+#if defined(__FDPIC__) && defined(HAVE_DL_ITERATE_PHDR) && (defined(HAVE_LINK_H) || defined(HAVE_SYS_LINK_H))
+
+#ifdef HAVE_LINK_H
+ #include <link.h>
+#endif
+#ifdef HAVE_SYS_LINK_H
+ #include <sys/link.h>
+#endif
+
+#define libbacktrace_using_fdpic() (1)
+
+struct libbacktrace_base_address
+{
+  struct elf32_fdpic_loadaddr m;
+};
+
+#define libbacktrace_add_base(pc, base) \
+  ((uintptr_t) (__RELOC_POINTER ((pc), (base).m)))
+
+#else /* not _FDPIC__ */
+
+#define libbacktrace_using_fdpic() (0)
+
+struct libbacktrace_base_address
+{
+  uintptr_t m;
+};
+
+#define libbacktrace_add_base(pc, base) ((pc) + (base).m)
+
+#endif /* not _FDPIC__ */
+
 /* Add file/line information for a DWARF module.  */
 
 extern int backtrace_dwarf_add (struct backtrace_state *state,
-				uintptr_t base_address,
+				struct libbacktrace_base_address base_address,
 				const struct dwarf_sections *dwarf_sections,
 				int is_bigendian,
 				struct dwarf_data *fileline_altlink,

--- a/tracy-client-sys/tracy/libbacktrace/macho.cpp
+++ b/tracy-client-sys/tracy/libbacktrace/macho.cpp
@@ -274,12 +274,14 @@ struct macho_nlist_64
 
 /* Value found in nlist n_type field.  */
 
-#define MACH_O_N_EXT	0x01	/* Extern symbol */
-#define MACH_O_N_ABS	0x02	/* Absolute symbol */
-#define MACH_O_N_SECT	0x0e	/* Defined in section */
-
-#define MACH_O_N_TYPE	0x0e	/* Mask for type bits */
 #define MACH_O_N_STAB	0xe0	/* Stabs debugging symbol */
+#define MACH_O_N_TYPE	0x0e	/* Mask for type bits */
+
+/* Values found after masking with MACH_O_N_TYPE.  */
+#define MACH_O_N_UNDF	0x00	/* Undefined symbol */
+#define MACH_O_N_ABS	0x02	/* Absolute symbol */
+#define MACH_O_N_SECT	0x0e	/* Defined in section from n_sect field */
+
 
 /* Information we keep for a Mach-O symbol.  */
 
@@ -316,8 +318,9 @@ static const char * const dwarf_section_names[DEBUG_MAX] =
 /* Forward declaration.  */
 
 static int macho_add (struct backtrace_state *, const char *, int, off_t,
-		      const unsigned char *, uintptr_t, int,
-		      backtrace_error_callback, void *, fileline *, int *);
+		      const unsigned char *, struct libbacktrace_base_address,
+		      int, backtrace_error_callback, void *, fileline *,
+		      int *);
 
 /* A dummy callback function used when we can't find any debug info.  */
 
@@ -495,10 +498,10 @@ macho_defined_symbol (uint8_t type)
 {
   if ((type & MACH_O_N_STAB) != 0)
     return 0;
-  if ((type & MACH_O_N_EXT) != 0)
-    return 0;
   switch (type & MACH_O_N_TYPE)
     {
+    case MACH_O_N_UNDF:
+      return 0;
     case MACH_O_N_ABS:
       return 1;
     case MACH_O_N_SECT:
@@ -512,7 +515,7 @@ macho_defined_symbol (uint8_t type)
 
 static int
 macho_add_symtab (struct backtrace_state *state, int descriptor,
-		  uintptr_t base_address, int is_64,
+		  struct libbacktrace_base_address base_address, int is_64,
 		  off_t symoff, unsigned int nsyms, off_t stroff,
 		  unsigned int strsize,
 		  backtrace_error_callback error_callback, void *data)
@@ -627,7 +630,7 @@ macho_add_symtab (struct backtrace_state *state, int descriptor,
       if (name[0] == '_')
 	++name;
       macho_symbols[j].name = name;
-      macho_symbols[j].address = value + base_address;
+      macho_symbols[j].address = libbacktrace_add_base (value, base_address);
       ++j;
     }
 
@@ -760,7 +763,8 @@ macho_syminfo (struct backtrace_state *state, uintptr_t addr,
 static int
 macho_add_fat (struct backtrace_state *state, const char *filename,
 	       int descriptor, int swapped, off_t offset,
-	       const unsigned char *match_uuid, uintptr_t base_address,
+	       const unsigned char *match_uuid,
+	       struct libbacktrace_base_address base_address,
 	       int skip_symtab, uint32_t nfat_arch, int is_64,
 	       backtrace_error_callback error_callback, void *data,
 	       fileline *fileline_fn, int *found_sym)
@@ -862,7 +866,8 @@ macho_add_fat (struct backtrace_state *state, const char *filename,
 
 static int
 macho_add_dsym (struct backtrace_state *state, const char *filename,
-		uintptr_t base_address, const unsigned char *uuid,
+		struct libbacktrace_base_address base_address,
+		const unsigned char *uuid,
 		backtrace_error_callback error_callback, void *data,
 		fileline* fileline_fn)
 {
@@ -980,7 +985,7 @@ macho_add_dsym (struct backtrace_state *state, const char *filename,
 static int
 macho_add (struct backtrace_state *state, const char *filename, int descriptor,
 	   off_t offset, const unsigned char *match_uuid,
-	   uintptr_t base_address, int skip_symtab,
+	   struct libbacktrace_base_address base_address, int skip_symtab,
 	   backtrace_error_callback error_callback, void *data,
 	   fileline *fileline_fn, int *found_sym)
 {
@@ -1242,7 +1247,7 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
   c = _dyld_image_count ();
   for (i = 0; i < c; ++i)
     {
-      uintptr_t base_address;
+      struct libbacktrace_base_address base_address;
       const char *name;
       int d;
       fileline mff;
@@ -1266,7 +1271,7 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
 	    continue;
 	}
 
-      base_address = _dyld_get_image_vmaddr_slide (i);
+      base_address.m = _dyld_get_image_vmaddr_slide (i);
 
       mff = macho_nodebug;
       if (!macho_add (state, name, d, 0, NULL, base_address, 0,
@@ -1321,10 +1326,12 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
 		      void *data, fileline *fileline_fn)
 {
   fileline macho_fileline_fn;
+  struct libbacktrace_base_address zero_base_address;
   int found_sym;
 
   macho_fileline_fn = macho_nodebug;
-  if (!macho_add (state, filename, descriptor, 0, NULL, 0, 0,
+  memset (&zero_base_address, 0, sizeof zero_base_address);
+  if (!macho_add (state, filename, descriptor, 0, NULL, zero_base_address, 0,
 		  error_callback, data, &macho_fileline_fn, &found_sym))
     return 0;
 

--- a/tracy-client-sys/tracy/tracy/Tracy.hpp
+++ b/tracy-client-sys/tracy/tracy/Tracy.hpp
@@ -13,7 +13,7 @@
 #endif
 
 #ifndef TracyLine
-#  define TracyLine __LINE__
+#  define TracyLine TracyConcat(__LINE__,U) // MSVC Edit and continue __LINE__ is non-constant. See https://developercommunity.visualstudio.com/t/-line-cannot-be-used-as-an-argument-for-constexpr/195665
 #endif
 
 #ifndef TRACY_ENABLE
@@ -75,8 +75,10 @@
 
 #define TracyAlloc(x,y)
 #define TracyFree(x)
+#define TracyMemoryDiscard(x)
 #define TracySecureAlloc(x,y)
 #define TracySecureFree(x)
+#define TracySecureMemoryDiscard(x)
 
 #define TracyAllocN(x,y,z)
 #define TracyFreeN(x,y)
@@ -98,8 +100,10 @@
 
 #define TracyAllocS(x,y,z)
 #define TracyFreeS(x,y)
+#define TracyMemoryDiscardS(x,y)
 #define TracySecureAllocS(x,y,z)
 #define TracySecureFreeS(x,y)
+#define TracySecureMemoryDiscardS(x,y)
 
 #define TracyAllocNS(x,y,z,w)
 #define TracyFreeNS(x,y,z)
@@ -130,27 +134,20 @@
 #include "../client/TracyProfiler.hpp"
 #include "../client/TracyScoped.hpp"
 
+#ifndef TRACY_CALLSTACK
+#define TRACY_CALLSTACK 0
+#endif
+
 #define TracyNoop tracy::ProfilerAvailable()
 
-#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
-#  define ZoneNamed( varname, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active )
-#  define ZoneNamedN( varname, name, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active )
-#  define ZoneNamedC( varname, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active )
-#  define ZoneNamedNC( varname, name, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active )
+#define ZoneNamed( varname, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active )
+#define ZoneNamedN( varname, name, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active )
+#define ZoneNamedC( varname, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active )
+#define ZoneNamedNC( varname, name, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active )
 
-#  define ZoneTransient( varname, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), nullptr, 0, TRACY_CALLSTACK, active )
-#  define ZoneTransientN( varname, name, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), TRACY_CALLSTACK, active )
-#  define ZoneTransientNC( varname, name, color, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), color, TRACY_CALLSTACK, active )
-#else
-#  define ZoneNamed( varname, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), active )
-#  define ZoneNamedN( varname, name, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), active )
-#  define ZoneNamedC( varname, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), active )
-#  define ZoneNamedNC( varname, name, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), active )
-
-#  define ZoneTransient( varname, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), nullptr, 0, active )
-#  define ZoneTransientN( varname, name, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), active )
-#  define ZoneTransientNC( varname, name, color, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), color, active )
-#endif
+#define ZoneTransient( varname, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), nullptr, 0, TRACY_CALLSTACK, active )
+#define ZoneTransientN( varname, name, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), TRACY_CALLSTACK, active )
+#define ZoneTransientNC( varname, name, color, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), color, TRACY_CALLSTACK, active )
 
 #define ZoneScoped ZoneNamed( ___tracy_scoped_zone, true )
 #define ZoneScopedN( name ) ZoneNamedN( ___tracy_scoped_zone, name, true )
@@ -185,7 +182,7 @@
 #define TracySharedLockableN( type, varname, desc ) tracy::SharedLockable<type> varname { [] () -> const tracy::SourceLocationData* { static constexpr tracy::SourceLocationData srcloc { nullptr, desc, TracyFile, TracyLine, 0 }; return &srcloc; }() }
 #define LockableBase( type ) tracy::Lockable<type>
 #define SharedLockableBase( type ) tracy::SharedLockable<type>
-#define LockMark( varname ) static constexpr tracy::SourceLocationData __tracy_lock_location_##varname { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; varname.Mark( &__tracy_lock_location_##varname )
+#define LockMark( varname ) static constexpr tracy::SourceLocationData __tracy_lock_location_##__LINE__ { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; varname.Mark( &__tracy_lock_location_##__LINE__ )
 #define LockableName( varname, txt, size ) varname.CustomName( txt, size )
 
 #define TracyPlot( name, val ) tracy::Profiler::PlotData( name, val )
@@ -193,95 +190,52 @@
 
 #define TracyAppInfo( txt, size ) tracy::Profiler::MessageAppInfo( txt, size )
 
-#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
-#  define TracyMessage( txt, size ) tracy::Profiler::Message( txt, size, TRACY_CALLSTACK )
-#  define TracyMessageL( txt ) tracy::Profiler::Message( txt, TRACY_CALLSTACK )
-#  define TracyMessageC( txt, size, color ) tracy::Profiler::MessageColor( txt, size, color, TRACY_CALLSTACK )
-#  define TracyMessageLC( txt, color ) tracy::Profiler::MessageColor( txt, color, TRACY_CALLSTACK )
+#define TracyMessage( txt, size ) tracy::Profiler::Message( txt, size, TRACY_CALLSTACK )
+#define TracyMessageL( txt ) tracy::Profiler::Message( txt, TRACY_CALLSTACK )
+#define TracyMessageC( txt, size, color ) tracy::Profiler::MessageColor( txt, size, color, TRACY_CALLSTACK )
+#define TracyMessageLC( txt, color ) tracy::Profiler::MessageColor( txt, color, TRACY_CALLSTACK )
 
-#  define TracyAlloc( ptr, size ) tracy::Profiler::MemAllocCallstack( ptr, size, TRACY_CALLSTACK, false )
-#  define TracyFree( ptr ) tracy::Profiler::MemFreeCallstack( ptr, TRACY_CALLSTACK, false )
-#  define TracySecureAlloc( ptr, size ) tracy::Profiler::MemAllocCallstack( ptr, size, TRACY_CALLSTACK, true )
-#  define TracySecureFree( ptr ) tracy::Profiler::MemFreeCallstack( ptr, TRACY_CALLSTACK, true )
+#define TracyAlloc( ptr, size ) tracy::Profiler::MemAllocCallstack( ptr, size, TRACY_CALLSTACK, false )
+#define TracyFree( ptr ) tracy::Profiler::MemFreeCallstack( ptr, TRACY_CALLSTACK, false )
+#define TracySecureAlloc( ptr, size ) tracy::Profiler::MemAllocCallstack( ptr, size, TRACY_CALLSTACK, true )
+#define TracySecureFree( ptr ) tracy::Profiler::MemFreeCallstack( ptr, TRACY_CALLSTACK, true )
 
-#  define TracyAllocN( ptr, size, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, TRACY_CALLSTACK, false, name )
-#  define TracyFreeN( ptr, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, TRACY_CALLSTACK, false, name )
-#  define TracySecureAllocN( ptr, size, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, TRACY_CALLSTACK, true, name )
-#  define TracySecureFreeN( ptr, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, TRACY_CALLSTACK, true, name )
-#else
-#  define TracyMessage( txt, size ) tracy::Profiler::Message( txt, size, 0 )
-#  define TracyMessageL( txt ) tracy::Profiler::Message( txt, 0 )
-#  define TracyMessageC( txt, size, color ) tracy::Profiler::MessageColor( txt, size, color, 0 )
-#  define TracyMessageLC( txt, color ) tracy::Profiler::MessageColor( txt, color, 0 )
+#define TracyAllocN( ptr, size, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, TRACY_CALLSTACK, false, name )
+#define TracyFreeN( ptr, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, TRACY_CALLSTACK, false, name )
+#define TracyMemoryDiscard( name ) tracy::Profiler::MemDiscardCallstack( name, false, TRACY_CALLSTACK )
+#define TracySecureAllocN( ptr, size, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, TRACY_CALLSTACK, true, name )
+#define TracySecureFreeN( ptr, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, TRACY_CALLSTACK, true, name )
+#define TracySecureMemoryDiscard( name ) tracy::Profiler::MemDiscardCallstack( name, true, TRACY_CALLSTACK )
 
-#  define TracyAlloc( ptr, size ) tracy::Profiler::MemAlloc( ptr, size, false )
-#  define TracyFree( ptr ) tracy::Profiler::MemFree( ptr, false )
-#  define TracySecureAlloc( ptr, size ) tracy::Profiler::MemAlloc( ptr, size, true )
-#  define TracySecureFree( ptr ) tracy::Profiler::MemFree( ptr, true )
+#define ZoneNamedS( varname, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
+#define ZoneNamedNS( varname, name, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
+#define ZoneNamedCS( varname, color, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
+#define ZoneNamedNCS( varname, name, color, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
 
-#  define TracyAllocN( ptr, size, name ) tracy::Profiler::MemAllocNamed( ptr, size, false, name )
-#  define TracyFreeN( ptr, name ) tracy::Profiler::MemFreeNamed( ptr, false, name )
-#  define TracySecureAllocN( ptr, size, name ) tracy::Profiler::MemAllocNamed( ptr, size, true, name )
-#  define TracySecureFreeN( ptr, name ) tracy::Profiler::MemFreeNamed( ptr, true, name )
-#endif
+#define ZoneTransientS( varname, depth, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), nullptr, 0, depth, active )
+#define ZoneTransientNS( varname, name, depth, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), depth, active )
 
-#ifdef TRACY_HAS_CALLSTACK
-#  define ZoneNamedS( varname, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
-#  define ZoneNamedNS( varname, name, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
-#  define ZoneNamedCS( varname, color, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
-#  define ZoneNamedNCS( varname, name, color, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::ScopedZone varname( &TracyConcat(__tracy_source_location,TracyLine), depth, active )
+#define ZoneScopedS( depth ) ZoneNamedS( ___tracy_scoped_zone, depth, true )
+#define ZoneScopedNS( name, depth ) ZoneNamedNS( ___tracy_scoped_zone, name, depth, true )
+#define ZoneScopedCS( color, depth ) ZoneNamedCS( ___tracy_scoped_zone, color, depth, true )
+#define ZoneScopedNCS( name, color, depth ) ZoneNamedNCS( ___tracy_scoped_zone, name, color, depth, true )
 
-#  define ZoneTransientS( varname, depth, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), nullptr, 0, depth, active )
-#  define ZoneTransientNS( varname, name, depth, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), depth, active )
+#define TracyAllocS( ptr, size, depth ) tracy::Profiler::MemAllocCallstack( ptr, size, depth, false )
+#define TracyFreeS( ptr, depth ) tracy::Profiler::MemFreeCallstack( ptr, depth, false )
+#define TracySecureAllocS( ptr, size, depth ) tracy::Profiler::MemAllocCallstack( ptr, size, depth, true )
+#define TracySecureFreeS( ptr, depth ) tracy::Profiler::MemFreeCallstack( ptr, depth, true )
 
-#  define ZoneScopedS( depth ) ZoneNamedS( ___tracy_scoped_zone, depth, true )
-#  define ZoneScopedNS( name, depth ) ZoneNamedNS( ___tracy_scoped_zone, name, depth, true )
-#  define ZoneScopedCS( color, depth ) ZoneNamedCS( ___tracy_scoped_zone, color, depth, true )
-#  define ZoneScopedNCS( name, color, depth ) ZoneNamedNCS( ___tracy_scoped_zone, name, color, depth, true )
+#define TracyAllocNS( ptr, size, depth, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, false, name )
+#define TracyFreeNS( ptr, depth, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, depth, false, name )
+#define TracyMemoryDiscardS( name, depth ) tracy::Profiler::MemDiscardCallstack( name, false, depth )
+#define TracySecureAllocNS( ptr, size, depth, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, true, name )
+#define TracySecureFreeNS( ptr, depth, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, depth, true, name )
+#define TracySecureMemoryDiscardS( name, depth ) tracy::Profiler::MemDiscardCallstack( name, true, depth )
 
-#  define TracyAllocS( ptr, size, depth ) tracy::Profiler::MemAllocCallstack( ptr, size, depth, false )
-#  define TracyFreeS( ptr, depth ) tracy::Profiler::MemFreeCallstack( ptr, depth, false )
-#  define TracySecureAllocS( ptr, size, depth ) tracy::Profiler::MemAllocCallstack( ptr, size, depth, true )
-#  define TracySecureFreeS( ptr, depth ) tracy::Profiler::MemFreeCallstack( ptr, depth, true )
-
-#  define TracyAllocNS( ptr, size, depth, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, false, name )
-#  define TracyFreeNS( ptr, depth, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, depth, false, name )
-#  define TracySecureAllocNS( ptr, size, depth, name ) tracy::Profiler::MemAllocCallstackNamed( ptr, size, depth, true, name )
-#  define TracySecureFreeNS( ptr, depth, name ) tracy::Profiler::MemFreeCallstackNamed( ptr, depth, true, name )
-
-#  define TracyMessageS( txt, size, depth ) tracy::Profiler::Message( txt, size, depth )
-#  define TracyMessageLS( txt, depth ) tracy::Profiler::Message( txt, depth )
-#  define TracyMessageCS( txt, size, color, depth ) tracy::Profiler::MessageColor( txt, size, color, depth )
-#  define TracyMessageLCS( txt, color, depth ) tracy::Profiler::MessageColor( txt, color, depth )
-#else
-#  define ZoneNamedS( varname, depth, active ) ZoneNamed( varname, active )
-#  define ZoneNamedNS( varname, name, depth, active ) ZoneNamedN( varname, name, active )
-#  define ZoneNamedCS( varname, color, depth, active ) ZoneNamedC( varname, color, active )
-#  define ZoneNamedNCS( varname, name, color, depth, active ) ZoneNamedNC( varname, name, color, active )
-
-#  define ZoneTransientS( varname, depth, active ) ZoneTransient( varname, active )
-#  define ZoneTransientNS( varname, name, depth, active ) ZoneTransientN( varname, name, active )
-
-#  define ZoneScopedS( depth ) ZoneScoped
-#  define ZoneScopedNS( name, depth ) ZoneScopedN( name )
-#  define ZoneScopedCS( color, depth ) ZoneScopedC( color )
-#  define ZoneScopedNCS( name, color, depth ) ZoneScopedNC( name, color )
-
-#  define TracyAllocS( ptr, size, depth ) TracyAlloc( ptr, size )
-#  define TracyFreeS( ptr, depth ) TracyFree( ptr )
-#  define TracySecureAllocS( ptr, size, depth ) TracySecureAlloc( ptr, size )
-#  define TracySecureFreeS( ptr, depth ) TracySecureFree( ptr )
-
-#  define TracyAllocNS( ptr, size, depth, name ) TracyAllocN( ptr, size, name )
-#  define TracyFreeNS( ptr, depth, name ) TracyFreeN( ptr, name )
-#  define TracySecureAllocNS( ptr, size, depth, name ) TracySecureAllocN( ptr, size, name )
-#  define TracySecureFreeNS( ptr, depth, name ) TracySecureFreeN( ptr, name )
-
-#  define TracyMessageS( txt, size, depth ) TracyMessage( txt, size )
-#  define TracyMessageLS( txt, depth ) TracyMessageL( txt )
-#  define TracyMessageCS( txt, size, color, depth ) TracyMessageC( txt, size, color )
-#  define TracyMessageLCS( txt, color, depth ) TracyMessageLC( txt, color )
-#endif
+#define TracyMessageS( txt, size, depth ) tracy::Profiler::Message( txt, size, depth )
+#define TracyMessageLS( txt, depth ) tracy::Profiler::Message( txt, depth )
+#define TracyMessageCS( txt, size, color, depth ) tracy::Profiler::MessageColor( txt, size, color, depth )
+#define TracyMessageLCS( txt, color, depth ) tracy::Profiler::MessageColor( txt, color, depth )
 
 #define TracySourceCallbackRegister( cb, data ) tracy::Profiler::SourceCallbackRegister( cb, data )
 #define TracyParameterRegister( cb, data ) tracy::Profiler::ParameterRegister( cb, data )

--- a/tracy-client-sys/tracy/tracy/TracyC.h
+++ b/tracy-client-sys/tracy/tracy/TracyC.h
@@ -4,7 +4,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "../client/TracyCallstack.h"
 #include "../common/TracyApi.h"
 
 #ifdef __cplusplus
@@ -53,8 +52,10 @@ typedef const void* TracyCLockCtx;
 
 #define TracyCAlloc(x,y)
 #define TracyCFree(x)
+#define TracyCMemoryDiscard(x)
 #define TracyCSecureAlloc(x,y)
 #define TracyCSecureFree(x)
+#define TracyCSecureMemoryDiscard(x)
 
 #define TracyCAllocN(x,y,z)
 #define TracyCFreeN(x,y)
@@ -85,8 +86,10 @@ typedef const void* TracyCLockCtx;
 
 #define TracyCAllocS(x,y,z)
 #define TracyCFreeS(x,y)
+#define TracyCMemoryDiscardS(x,y)
 #define TracyCSecureAllocS(x,y,z)
 #define TracyCSecureFreeS(x,y)
+#define TracyCSecureMemoryDiscardS(x,y)
 
 #define TracyCAllocNS(x,y,z,w)
 #define TracyCFreeNS(x,y,z)
@@ -137,7 +140,7 @@ struct ___tracy_source_location_data
 struct ___tracy_c_zone_context
 {
     uint32_t id;
-    int active;
+    int32_t active;
 };
 
 struct ___tracy_gpu_time_data
@@ -155,7 +158,7 @@ struct ___tracy_gpu_zone_begin_data {
 
 struct ___tracy_gpu_zone_begin_callstack_data {
     uint64_t srcloc;
-    int depth;
+    int32_t depth;
     uint16_t queryId;
     uint8_t context;
 };
@@ -201,7 +204,7 @@ typedef struct __tracy_lockable_context_data* TracyCLockCtx;
 #ifdef TRACY_MANUAL_LIFETIME
 TRACY_API void ___tracy_startup_profiler(void);
 TRACY_API void ___tracy_shutdown_profiler(void);
-TRACY_API int ___tracy_profiler_started(void);
+TRACY_API int32_t ___tracy_profiler_started(void);
 
 #  define TracyCIsStarted ___tracy_profiler_started()
 #else
@@ -211,10 +214,10 @@ TRACY_API int ___tracy_profiler_started(void);
 TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, uint32_t color );
 TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color );
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int active );
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int active );
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int active );
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int depth, int active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int32_t active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int32_t depth, int32_t active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int32_t depth, int32_t active );
 TRACY_API void ___tracy_emit_zone_end( TracyCZoneCtx ctx );
 TRACY_API void ___tracy_emit_zone_text( TracyCZoneCtx ctx, const char* txt, size_t size );
 TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size_t size );
@@ -243,19 +246,16 @@ TRACY_API void ___tracy_emit_gpu_context_name_serial( const struct ___tracy_gpu_
 TRACY_API void ___tracy_emit_gpu_calibration_serial( const struct ___tracy_gpu_calibration_data );
 TRACY_API void ___tracy_emit_gpu_time_sync_serial( const struct ___tracy_gpu_time_sync_data );
 
-TRACY_API int ___tracy_connected(void);
+TRACY_API int32_t ___tracy_connected(void);
 
-#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
-#  define TracyCZone( ctx, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active );
-#  define TracyCZoneN( ctx, name, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active );
-#  define TracyCZoneC( ctx, color, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active );
-#  define TracyCZoneNC( ctx, name, color, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active );
-#else
-#  define TracyCZone( ctx, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin( &TracyConcat(__tracy_source_location,TracyLine), active );
-#  define TracyCZoneN( ctx, name, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin( &TracyConcat(__tracy_source_location,TracyLine), active );
-#  define TracyCZoneC( ctx, color, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin( &TracyConcat(__tracy_source_location,TracyLine), active );
-#  define TracyCZoneNC( ctx, name, color, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin( &TracyConcat(__tracy_source_location,TracyLine), active );
+#ifndef TRACY_CALLSTACK
+#define TRACY_CALLSTACK 0
 #endif
+
+#define TracyCZone( ctx, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active );
+#define TracyCZoneN( ctx, name, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active );
+#define TracyCZoneC( ctx, color, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active );
+#define TracyCZoneNC( ctx, name, color, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), TRACY_CALLSTACK, active );
 
 #define TracyCZoneEnd( ctx ) ___tracy_emit_zone_end( ctx );
 
@@ -265,57 +265,44 @@ TRACY_API int ___tracy_connected(void);
 #define TracyCZoneValue( ctx, value ) ___tracy_emit_zone_value( ctx, value );
 
 
-TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int secure );
-TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int depth, int secure );
-TRACY_API void ___tracy_emit_memory_free( const void* ptr, int secure );
-TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, int secure );
-TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int secure, const char* name );
-TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int depth, int secure, const char* name );
-TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int secure, const char* name );
-TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int depth, int secure, const char* name );
+TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int32_t secure );
+TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int32_t depth, int32_t secure );
+TRACY_API void ___tracy_emit_memory_free( const void* ptr, int32_t secure );
+TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int32_t depth, int32_t secure );
+TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int32_t depth, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32_t depth, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure );
+TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int32_t depth );
 
-TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int callstack );
-TRACY_API void ___tracy_emit_messageL( const char* txt, int callstack );
-TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int callstack );
-TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int callstack );
+TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int32_t callstack_depth );
+TRACY_API void ___tracy_emit_messageL( const char* txt, int32_t callstack_depth );
+TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int32_t callstack_depth );
+TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int32_t callstack_depth );
 
-#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
-#  define TracyCAlloc( ptr, size ) ___tracy_emit_memory_alloc_callstack( ptr, size, TRACY_CALLSTACK, 0 )
-#  define TracyCFree( ptr ) ___tracy_emit_memory_free_callstack( ptr, TRACY_CALLSTACK, 0 )
-#  define TracyCSecureAlloc( ptr, size ) ___tracy_emit_memory_alloc_callstack( ptr, size, TRACY_CALLSTACK, 1 )
-#  define TracyCSecureFree( ptr ) ___tracy_emit_memory_free_callstack( ptr, TRACY_CALLSTACK, 1 )
+#define TracyCAlloc( ptr, size ) ___tracy_emit_memory_alloc_callstack( ptr, size, TRACY_CALLSTACK, 0 )
+#define TracyCFree( ptr ) ___tracy_emit_memory_free_callstack( ptr, TRACY_CALLSTACK, 0 )
+#define TracyCMemoryDiscard( name ) ___tracy_emit_memory_discard_callstack( name, 0, TRACY_CALLSTACK );
+#define TracyCSecureAlloc( ptr, size ) ___tracy_emit_memory_alloc_callstack( ptr, size, TRACY_CALLSTACK, 1 )
+#define TracyCSecureFree( ptr ) ___tracy_emit_memory_free_callstack( ptr, TRACY_CALLSTACK, 1 )
+#define TracyCSecureMemoryDiscard( name ) ___tracy_emit_memory_discard_callstack( name, 1, TRACY_CALLSTACK );
 
-#  define TracyCAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, TRACY_CALLSTACK, 0, name )
-#  define TracyCFreeN( ptr, name ) ___tracy_emit_memory_free_callstack_named( ptr, TRACY_CALLSTACK, 0, name )
-#  define TracyCSecureAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, TRACY_CALLSTACK, 1, name )
-#  define TracyCSecureFreeN( ptr, name ) ___tracy_emit_memory_free_callstack_named( ptr, TRACY_CALLSTACK, 1, name )
+#define TracyCAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, TRACY_CALLSTACK, 0, name )
+#define TracyCFreeN( ptr, name ) ___tracy_emit_memory_free_callstack_named( ptr, TRACY_CALLSTACK, 0, name )
+#define TracyCSecureAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, TRACY_CALLSTACK, 1, name )
+#define TracyCSecureFreeN( ptr, name ) ___tracy_emit_memory_free_callstack_named( ptr, TRACY_CALLSTACK, 1, name )
 
-#  define TracyCMessage( txt, size ) ___tracy_emit_message( txt, size, TRACY_CALLSTACK );
-#  define TracyCMessageL( txt ) ___tracy_emit_messageL( txt, TRACY_CALLSTACK );
-#  define TracyCMessageC( txt, size, color ) ___tracy_emit_messageC( txt, size, color, TRACY_CALLSTACK );
-#  define TracyCMessageLC( txt, color ) ___tracy_emit_messageLC( txt, color, TRACY_CALLSTACK );
-#else
-#  define TracyCAlloc( ptr, size ) ___tracy_emit_memory_alloc( ptr, size, 0 );
-#  define TracyCFree( ptr ) ___tracy_emit_memory_free( ptr, 0 );
-#  define TracyCSecureAlloc( ptr, size ) ___tracy_emit_memory_alloc( ptr, size, 1 );
-#  define TracyCSecureFree( ptr ) ___tracy_emit_memory_free( ptr, 1 );
-
-#  define TracyCAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_named( ptr, size, 0, name );
-#  define TracyCFreeN( ptr, name ) ___tracy_emit_memory_free_named( ptr, 0, name );
-#  define TracyCSecureAllocN( ptr, size, name ) ___tracy_emit_memory_alloc_named( ptr, size, 1, name );
-#  define TracyCSecureFreeN( ptr, name ) ___tracy_emit_memory_free_named( ptr, 1, name );
-
-#  define TracyCMessage( txt, size ) ___tracy_emit_message( txt, size, 0 );
-#  define TracyCMessageL( txt ) ___tracy_emit_messageL( txt, 0 );
-#  define TracyCMessageC( txt, size, color ) ___tracy_emit_messageC( txt, size, color, 0 );
-#  define TracyCMessageLC( txt, color ) ___tracy_emit_messageLC( txt, color, 0 );
-#endif
+#define TracyCMessage( txt, size ) ___tracy_emit_message( txt, size, TRACY_CALLSTACK );
+#define TracyCMessageL( txt ) ___tracy_emit_messageL( txt, TRACY_CALLSTACK );
+#define TracyCMessageC( txt, size, color ) ___tracy_emit_messageC( txt, size, color, TRACY_CALLSTACK );
+#define TracyCMessageLC( txt, color ) ___tracy_emit_messageLC( txt, color, TRACY_CALLSTACK );
 
 
 TRACY_API void ___tracy_emit_frame_mark( const char* name );
 TRACY_API void ___tracy_emit_frame_mark_start( const char* name );
 TRACY_API void ___tracy_emit_frame_mark_end( const char* name );
-TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_t h, uint8_t offset, int flip );
+TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_t h, uint8_t offset, int32_t flip );
 
 #define TracyCFrameMark ___tracy_emit_frame_mark( 0 );
 #define TracyCFrameMarkNamed( name ) ___tracy_emit_frame_mark( name );
@@ -327,7 +314,7 @@ TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_
 TRACY_API void ___tracy_emit_plot( const char* name, double val );
 TRACY_API void ___tracy_emit_plot_float( const char* name, float val );
 TRACY_API void ___tracy_emit_plot_int( const char* name, int64_t val );
-TRACY_API void ___tracy_emit_plot_config( const char* name, int type, int step, int fill, uint32_t color );
+TRACY_API void ___tracy_emit_plot_config( const char* name, int32_t type, int32_t step, int32_t fill, uint32_t color );
 TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size );
 
 #define TracyCPlot( name, val ) ___tracy_emit_plot( name, val );
@@ -337,55 +324,35 @@ TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size );
 #define TracyCAppInfo( txt, size ) ___tracy_emit_message_appinfo( txt, size );
 
 
-#ifdef TRACY_HAS_CALLSTACK
-#  define TracyCZoneS( ctx, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
-#  define TracyCZoneNS( ctx, name, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
-#  define TracyCZoneCS( ctx, color, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
-#  define TracyCZoneNCS( ctx, name, color, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
+#define TracyCZoneS( ctx, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
+#define TracyCZoneNS( ctx, name, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, 0 }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
+#define TracyCZoneCS( ctx, color, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { NULL, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
+#define TracyCZoneNCS( ctx, name, color, depth, active ) static const struct ___tracy_source_location_data TracyConcat(__tracy_source_location,TracyLine) = { name, __func__,  TracyFile, (uint32_t)TracyLine, color }; TracyCZoneCtx ctx = ___tracy_emit_zone_begin_callstack( &TracyConcat(__tracy_source_location,TracyLine), depth, active );
 
-#  define TracyCAllocS( ptr, size, depth ) ___tracy_emit_memory_alloc_callstack( ptr, size, depth, 0 )
-#  define TracyCFreeS( ptr, depth ) ___tracy_emit_memory_free_callstack( ptr, depth, 0 )
-#  define TracyCSecureAllocS( ptr, size, depth ) ___tracy_emit_memory_alloc_callstack( ptr, size, depth, 1 )
-#  define TracyCSecureFreeS( ptr, depth ) ___tracy_emit_memory_free_callstack( ptr, depth, 1 )
+#define TracyCAllocS( ptr, size, depth ) ___tracy_emit_memory_alloc_callstack( ptr, size, depth, 0 )
+#define TracyCFreeS( ptr, depth ) ___tracy_emit_memory_free_callstack( ptr, depth, 0 )
+#define TracyCMemoryDiscardS( name, depth ) ___tracy_emit_memory_discard_callstack( name, 0, depth )
+#define TracyCSecureAllocS( ptr, size, depth ) ___tracy_emit_memory_alloc_callstack( ptr, size, depth, 1 )
+#define TracyCSecureFreeS( ptr, depth ) ___tracy_emit_memory_free_callstack( ptr, depth, 1 )
+#define TracyCSecureMemoryDiscardS( name, depth ) ___tracy_emit_memory_discard_callstack( name, 1, depth )
 
-#  define TracyCAllocNS( ptr, size, depth, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, depth, 0, name )
-#  define TracyCFreeNS( ptr, depth, name ) ___tracy_emit_memory_free_callstack_named( ptr, depth, 0, name )
-#  define TracyCSecureAllocNS( ptr, size, depth, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, depth, 1, name )
-#  define TracyCSecureFreeNS( ptr, depth, name ) ___tracy_emit_memory_free_callstack_named( ptr, depth, 1, name )
+#define TracyCAllocNS( ptr, size, depth, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, depth, 0, name )
+#define TracyCFreeNS( ptr, depth, name ) ___tracy_emit_memory_free_callstack_named( ptr, depth, 0, name )
+#define TracyCSecureAllocNS( ptr, size, depth, name ) ___tracy_emit_memory_alloc_callstack_named( ptr, size, depth, 1, name )
+#define TracyCSecureFreeNS( ptr, depth, name ) ___tracy_emit_memory_free_callstack_named( ptr, depth, 1, name )
 
-#  define TracyCMessageS( txt, size, depth ) ___tracy_emit_message( txt, size, depth );
-#  define TracyCMessageLS( txt, depth ) ___tracy_emit_messageL( txt, depth );
-#  define TracyCMessageCS( txt, size, color, depth ) ___tracy_emit_messageC( txt, size, color, depth );
-#  define TracyCMessageLCS( txt, color, depth ) ___tracy_emit_messageLC( txt, color, depth );
-#else
-#  define TracyCZoneS( ctx, depth, active ) TracyCZone( ctx, active )
-#  define TracyCZoneNS( ctx, name, depth, active ) TracyCZoneN( ctx, name, active )
-#  define TracyCZoneCS( ctx, color, depth, active ) TracyCZoneC( ctx, color, active )
-#  define TracyCZoneNCS( ctx, name, color, depth, active ) TracyCZoneNC( ctx, name, color, active )
-
-#  define TracyCAllocS( ptr, size, depth ) TracyCAlloc( ptr, size )
-#  define TracyCFreeS( ptr, depth ) TracyCFree( ptr )
-#  define TracyCSecureAllocS( ptr, size, depth ) TracyCSecureAlloc( ptr, size )
-#  define TracyCSecureFreeS( ptr, depth ) TracyCSecureFree( ptr )
-
-#  define TracyCAllocNS( ptr, size, depth, name ) TracyCAllocN( ptr, size, name )
-#  define TracyCFreeNS( ptr, depth, name ) TracyCFreeN( ptr, name )
-#  define TracyCSecureAllocNS( ptr, size, depth, name ) TracyCSecureAllocN( ptr, size, name )
-#  define TracyCSecureFreeNS( ptr, depth, name ) TracyCSecureFreeN( ptr, name )
-
-#  define TracyCMessageS( txt, size, depth ) TracyCMessage( txt, size )
-#  define TracyCMessageLS( txt, depth ) TracyCMessageL( txt )
-#  define TracyCMessageCS( txt, size, color, depth ) TracyCMessageC( txt, size, color )
-#  define TracyCMessageLCS( txt, color, depth ) TracyCMessageLC( txt, color )
-#endif
+#define TracyCMessageS( txt, size, depth ) ___tracy_emit_message( txt, size, depth );
+#define TracyCMessageLS( txt, depth ) ___tracy_emit_messageL( txt, depth );
+#define TracyCMessageCS( txt, size, color, depth ) ___tracy_emit_messageC( txt, size, color, depth );
+#define TracyCMessageLCS( txt, color, depth ) ___tracy_emit_messageLC( txt, color, depth );
 
 
 TRACY_API struct __tracy_lockable_context_data* ___tracy_announce_lockable_ctx( const struct ___tracy_source_location_data* srcloc );
 TRACY_API void ___tracy_terminate_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
-TRACY_API int ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
+TRACY_API int32_t ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
 TRACY_API void ___tracy_after_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
 TRACY_API void ___tracy_after_unlock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
-TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int acquired );
+TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int32_t acquired );
 TRACY_API void ___tracy_mark_lockable_ctx( struct __tracy_lockable_context_data* lockdata, const struct ___tracy_source_location_data* srcloc );
 TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_context_data* lockdata, const char* name, size_t nameSz );
 

--- a/tracy-client-sys/tracy/tracy/TracyCUDA.hpp
+++ b/tracy-client-sys/tracy/tracy/TracyCUDA.hpp
@@ -1,0 +1,1325 @@
+#ifndef __TRACYCUDA_HPP__
+#define __TRACYCUDA_HPP__
+
+#ifndef TRACY_ENABLE
+
+#define TracyCUDAContext() nullptr
+#define TracyCUDAContextDestroy(ctx)
+#define TracyCUDAContextName(ctx, name, size)
+
+#define TracyCUDAStartProfiling(ctx)
+#define TracyCUDAStopProfiling(ctx)
+
+#define TracyCUDACollect(ctx)
+
+#else
+#include <cupti.h>
+
+#include <cassert>
+#include <cmath>
+#include <string>
+#include <string_view>
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
+#include <condition_variable>
+#include <vector>
+#include <unordered_set>
+#include <unordered_map>
+
+#ifndef _MSC_VER
+#include <cxxabi.h>
+#endif
+
+#include <tracy/Tracy.hpp>
+
+#ifndef UNREFERENCED
+#define UNREFERENCED(x) (void)x
+#endif//UNREFERENCED
+
+#ifndef TRACY_CUDA_CALIBRATED_CONTEXT
+#define TRACY_CUDA_CALIBRATED_CONTEXT (1)
+#endif//TRACY_CUDA_CALIBRATED_CONTEXT
+
+#ifndef TRACY_CUDA_ENABLE_COLLECTOR_THREAD
+#define TRACY_CUDA_ENABLE_COLLECTOR_THREAD (1)
+#endif//TRACY_CUDA_ENABLE_COLLECTOR_THREAD
+
+#ifndef TRACY_CUDA_ENABLE_CUDA_CALL_STATS
+#define TRACY_CUDA_ENABLE_CUDA_CALL_STATS (0)
+#endif//TRACY_CUDA_ENABLE_CUDA_CALL_STATS
+
+namespace {
+
+// TODO(marcos): wrap these in structs for better type safety
+using CUptiTimestamp = uint64_t;
+using TracyTimestamp =  int64_t;
+
+struct IncrementalRegression {
+    using float_t = double;
+    struct Parameters {
+        float_t slope, intercept;
+    };
+
+    int n = 0;
+    float_t x_mean = 0;
+    float_t y_mean = 0;
+    float_t x_svar = 0;
+    float_t y_svar = 0;
+    float_t xy_scov = 0;
+
+    auto parameters() const {
+        float_t slope = xy_scov / x_svar;
+        float_t intercept = y_mean - slope * x_mean;
+        return Parameters{ slope, intercept };
+    }
+
+    auto orthogonal() const {
+        // NOTE(marcos): orthogonal regression is Deming regression with delta = 1
+        float_t delta = float_t(1);   // delta = 1 -> orthogonal regression
+        float_t k = y_svar - delta * x_svar;
+        float_t slope = (k + sqrt(k * k + 4 * delta * xy_scov * xy_scov)) / (2 * xy_scov);
+        float_t intercept = y_mean - slope * x_mean;
+        return Parameters{ slope, intercept };
+    }
+
+    void addSample(float_t x, float_t y) {
+        ++n;
+        float_t x_mean_prev = x_mean;
+        float_t y_mean_prev = y_mean;
+        x_mean += (x - x_mean) / n;
+        y_mean += (y - y_mean) / n;
+        x_svar += (x - x_mean_prev) * (x - x_mean);
+        y_svar += (y - y_mean_prev) * (y - y_mean);
+        xy_scov += (x - x_mean_prev) * (y - y_mean);
+    }
+};
+
+tracy_force_inline TracyTimestamp tracyGetTimestamp() {
+    return tracy::Profiler::GetTime();
+}
+
+auto& getCachedRegressionParameters() {
+    // WARN(marcos): in theory, these linear regression parameters would be loaded/stored atomically;
+    // in practice, however, it should not matter so long as the loads/stores are not "sliced"
+    static IncrementalRegression::Parameters cached;
+    return cached;
+}
+
+TracyTimestamp tracyFromCUpti(CUptiTimestamp cuptiTime) {
+    // NOTE(marcos): linear regression estimate
+    // y_hat = slope * x + intercept | X: CUptiTimestamp, Y: TracyTimestamp
+    auto [slope, intercept] = getCachedRegressionParameters();
+    double y_hat = slope * cuptiTime + intercept;
+    TracyTimestamp tracyTime = TracyTimestamp(y_hat);
+    assert(tracyTime >= 0);
+    return tracyTime;
+}
+
+template<typename T, typename U>
+tracy_force_inline void tracyMemWrite(T& where,U what) {
+    static_assert(std::is_same_v<T, U>, "tracy::MemWrite: type mismatch.");
+    tracy::MemWrite(&where, what);
+}
+
+void* tracyMalloc(size_t bytes) {
+    return tracy::tracy_malloc(bytes);
+}
+
+void tracyFree(void* ptr) {
+    tracy::tracy_free(ptr);
+}
+
+void tracyZoneBegin(TracyTimestamp time, tracy::SourceLocationData* srcLoc) {
+    using namespace tracy;
+    TracyQueuePrepare(QueueType::ZoneBegin);
+    tracyMemWrite(item->zoneBegin.time, time);
+    tracyMemWrite(item->zoneBegin.srcloc, (uint64_t)srcLoc);
+    TracyQueueCommit(zoneBeginThread);
+}
+
+void tracyZoneEnd(TracyTimestamp time) {
+    using namespace tracy;
+    TracyQueuePrepare(QueueType::ZoneEnd);
+    tracyMemWrite(item->zoneEnd.time, time);
+    TracyQueueCommit(zoneEndThread);
+}
+
+void tracyPlot(const char* name, float value, TracyTimestamp time) {
+    using namespace tracy;
+    TracyLfqPrepare(QueueType::PlotDataFloat);
+    tracyMemWrite(item->plotDataFloat.name, (uint64_t)name);
+    tracyMemWrite(item->plotDataFloat.time, time);
+    tracyMemWrite(item->plotDataFloat.val, value);
+    TracyLfqCommit;
+}
+
+void tracyPlot(const char* name, float value, CUptiTimestamp time) {
+    tracyPlot(name, value, tracyFromCUpti(time));
+}
+
+void tracyPlotActivity(const char* name, TracyTimestamp start, TracyTimestamp end, float value = 1.0f, float baseline = 0.0f) {
+    tracyPlot(name, baseline, start);
+    tracyPlot(name, value, start + 3);
+    tracyPlot(name, value, end - 3);
+    tracyPlot(name, baseline, end);
+}
+
+void tracyPlotActivity(const char* name, CUptiTimestamp start, CUptiTimestamp end, float value = 1.0f, float baseline = 0.0f) {
+    tracyPlotActivity(name, tracyFromCUpti(start), tracyFromCUpti(end), value, baseline);
+}
+
+void tracyPlotBlip(const char* name, TracyTimestamp time, float value = 1.0f, float baseline = 0.0f) {
+    tracyPlot(name, baseline, time - 3);
+    tracyPlot(name, value, time);
+    tracyPlot(name, baseline, time + 3);
+}
+
+void tracyPlotBlip(const char* name, CUptiTimestamp time, float value = 1.0f, float baseline = 0.0f) {
+    tracyPlotBlip(name, tracyFromCUpti(time), value, baseline);
+}
+
+void tracyEmitMemAlloc(const char* name, const void* ptr, size_t size, TracyTimestamp time) {
+    using namespace tracy;
+    const auto thread = GetThreadHandle();
+
+    auto item = Profiler::QueueSerial();
+    tracyMemWrite(item->hdr.type, QueueType::MemNamePayload);
+    tracyMemWrite(item->memName.name, (uint64_t)name);
+    Profiler::QueueSerialFinish();
+
+    item = Profiler::QueueSerial();
+    tracyMemWrite(item->hdr.type, QueueType::MemAllocNamed);
+    tracyMemWrite(item->memAlloc.time, time);
+    tracyMemWrite(item->memAlloc.thread, thread);
+    tracyMemWrite(item->memAlloc.ptr, (uint64_t)ptr);
+
+    if (compile_time_condition<sizeof(size) == 4>::value)
+    {
+        memcpy(&item->memAlloc.size, &size, 4);
+        memset(&item->memAlloc.size + 4, 0, 2);
+    }
+    else
+    {
+        assert(sizeof(size) == 8);
+        memcpy(&item->memAlloc.size, &size, 4);
+        memcpy(((char *)&item->memAlloc.size) + 4, ((char *)&size) + 4, 2);
+    }
+    Profiler::QueueSerialFinish();
+}
+
+void tracyEmitMemFree(const char* name, const void* ptr, TracyTimestamp time) {
+    using namespace tracy;
+    const auto thread = GetThreadHandle();
+
+    auto item = Profiler::QueueSerial();
+    tracyMemWrite(item->hdr.type, QueueType::MemNamePayload);
+    tracyMemWrite(item->memName.name, (uint64_t)name);
+    Profiler::QueueSerialFinish();
+
+    item = Profiler::QueueSerial();
+    tracyMemWrite(item->hdr.type, QueueType::MemFreeNamed);
+    tracyMemWrite(item->memFree.time, time);
+    tracyMemWrite(item->memFree.thread, thread);
+    tracyMemWrite(item->memFree.ptr, (uint64_t)ptr);
+    Profiler::QueueSerialFinish();
+}
+
+void tracyEmitMemAlloc(const char* name, const void* ptr, size_t size, CUptiTimestamp cuptiTime) {
+    tracyEmitMemAlloc(name, ptr, size, tracyFromCUpti(cuptiTime));
+}
+
+void tracyEmitMemFree(const char* name, const void* ptr, CUptiTimestamp cuptiTime) {
+    tracyEmitMemFree(name, ptr, tracyFromCUpti(cuptiTime));
+}
+
+void tracyAnnounceGpuTimestamp(TracyTimestamp apiStart, TracyTimestamp apiEnd,
+    uint16_t queryId, uint8_t gpuContextId, 
+    const tracy::SourceLocationData* sourceLocation, uint32_t threadId) {
+    using namespace tracy;
+
+    auto item = Profiler::QueueSerial();
+    tracyMemWrite(item->hdr.type, QueueType::GpuZoneBeginSerial);
+    tracyMemWrite(item->gpuZoneBegin.cpuTime, apiStart);
+    tracyMemWrite(item->gpuZoneBegin.srcloc, (uint64_t)sourceLocation);
+    tracyMemWrite(item->gpuZoneBegin.thread, threadId);
+    tracyMemWrite(item->gpuZoneBegin.queryId, uint16_t(queryId+0));
+    tracyMemWrite(item->gpuZoneBegin.context, gpuContextId);
+    Profiler::QueueSerialFinish();
+
+    item = Profiler::QueueSerial();
+    tracyMemWrite(item->hdr.type, QueueType::GpuZoneEndSerial);
+    tracyMemWrite(item->gpuZoneEnd.cpuTime, apiEnd);
+    tracyMemWrite(item->gpuZoneEnd.thread, threadId);
+    tracyMemWrite(item->gpuZoneEnd.queryId, uint16_t(queryId+1));
+    tracyMemWrite(item->gpuZoneEnd.context, gpuContextId);
+    Profiler::QueueSerialFinish();
+}
+
+void tracySubmitGpuTimestamp(CUptiTimestamp gpuStart, CUptiTimestamp gpuEnd,
+    uint16_t queryId, uint8_t gpuContextId) {
+    using namespace tracy;
+
+    auto item = Profiler::QueueSerial();
+    tracyMemWrite(item->hdr.type, QueueType::GpuTime);
+    tracyMemWrite(item->gpuTime.gpuTime, (int64_t)gpuStart);
+    tracyMemWrite(item->gpuTime.queryId, uint16_t(queryId+0));
+    tracyMemWrite(item->gpuTime.context, gpuContextId);
+    Profiler::QueueSerialFinish();
+
+    item = Profiler::QueueSerial();
+    tracyMemWrite(item->hdr.type, QueueType::GpuTime);
+    tracyMemWrite(item->gpuTime.gpuTime, (int64_t)gpuEnd);
+    tracyMemWrite(item->gpuTime.queryId, uint16_t(queryId+1));
+    tracyMemWrite(item->gpuTime.context, gpuContextId);
+    Profiler::QueueSerialFinish();
+}
+
+#define CUPTI_API_CALL(call) CUptiCallChecked(call, #call, __FILE__, __LINE__)
+
+#define DRIVER_API_CALL(call) cudaDriverCallChecked(call, #call, __FILE__, __LINE__)
+
+CUptiResult CUptiCallChecked(CUptiResult result, const char* call, const char* file, int line) noexcept {
+    if (result == CUPTI_SUCCESS)
+        return result;
+    const char* resultMsg = "";
+    CUPTI_API_CALL(cuptiGetResultString(result, &resultMsg));   // maybe not a good idea to recurse here...
+    fprintf(stderr, "ERROR:\t%s:%d:\n\tfunction '%s' failed with error '%s'.\n", file, line, call, resultMsg);
+    //assert(result == CUPTI_SUCCESS);
+    return result;
+}
+
+CUresult cudaDriverCallChecked(CUresult result, const char* call, const char* file, int line) noexcept {
+    if (result == CUDA_SUCCESS)
+        return result;
+    const char* resultMsg = "";
+    DRIVER_API_CALL(cuGetErrorString(result, &resultMsg));   // maybe not a good idea to recurse here...
+    fprintf(stderr, "ERROR:\t%s:%d:\n\tfunction '%s' failed with error '%s'.\n", file, line, call, resultMsg);
+    //assert(result == CUDA_SUCCESS);
+    return result;
+}
+
+template<typename TKey, typename TValue>
+struct ConcurrentHashMap {
+    static constexpr bool instrument = false;
+    auto acquire_read_lock() {
+        if (m.try_lock_shared())
+            return std::shared_lock<std::shared_mutex>(m, std::adopt_lock);
+        ZoneNamedC(rwlock, tracy::Color::Tomato, instrument);
+        return std::shared_lock<std::shared_mutex>(m);
+    }
+    auto acquire_write_lock() {
+        if (m.try_lock())
+            return std::unique_lock<std::shared_mutex>(m, std::adopt_lock);
+        ZoneNamedC(wxlock, tracy::Color::Tomato, instrument);
+        return std::unique_lock<std::shared_mutex>(m);
+    }
+    std::unordered_map<TKey, TValue> mapping;
+    std::shared_mutex m;
+    auto& operator[](TKey key) {
+        {
+            auto lock = acquire_read_lock();
+            auto it = mapping.find(key);
+            if (it != mapping.end()) {
+                return it->second;
+            }
+        }
+        return emplace(key, TValue{}).first->second;
+    }
+    auto find(TKey key) {
+        ZoneNamed(find, instrument);
+        auto lock = acquire_read_lock();
+        return mapping.find(key);
+    }
+    auto fetch(TKey key, TValue& value) {
+        ZoneNamed(fetch, instrument);
+        auto it = mapping.find(key);
+        if (it != mapping.end()) {
+            value = it->second;
+            return true;
+        }
+        return false;
+    }
+    auto end() {
+        ZoneNamed(end, instrument);
+        auto lock = acquire_read_lock();
+        return mapping.end();
+    }
+    template<typename... Args>
+    auto emplace(TKey key, Args&&... args) {
+        ZoneNamed(emplace, instrument);
+        auto lock = acquire_write_lock();
+        return mapping.emplace(std::forward<TKey>(key), std::forward<Args>(args)...);
+    }
+    auto erase(TKey key) {
+        ZoneNamed(erase, instrument);
+        auto lock = acquire_write_lock();
+        return mapping.erase(key);
+    }
+};
+
+#if TRACY_CUDA_ENABLE_CUDA_CALL_STATS
+struct ProfilerStats {
+    static constexpr bool instrument = false;
+
+    ConcurrentHashMap<uint32_t, std::atomic<int>> apiCallCount;
+
+    void update(CUpti_CallbackDomain domain, CUpti_CallbackId cbid) {
+        ZoneNamed(update, instrument);
+        uint32_t key = (domain << 24) | (cbid & 0x00'FFFFFF);
+        auto it = apiCallCount.find(key);
+        if (it == apiCallCount.end()) {
+            it = apiCallCount.emplace(key, 0).first;
+        }
+        it->second.fetch_add(1, std::memory_order::memory_order_relaxed);
+    }
+};
+#endif
+
+// StringTable: string memoization/interning
+struct StringTable {
+    static constexpr bool instrument = false;
+
+    // TODO(marcos): this could be just a "ConcurrentHashSet"
+    ConcurrentHashMap<std::string_view, std::string_view> table;
+
+    ~StringTable() { /* TODO(marcos): free string copy */ }
+
+    std::string_view operator[](std::string_view str) {
+        ZoneNamedN(lookup, "StringTable::lookup", instrument);
+        std::string_view memoized;
+        if (!table.fetch(str, memoized)) {
+            ZoneNamedN(lookup, "StringTable::insert", instrument);
+            char* copy = (char*)tracyMalloc(str.size() + 1);
+            strncpy(copy, str.data(), str.size());
+            copy[str.size()] = '\0';
+            std::string_view value (copy, str.size());
+            auto [it, inserted] = table.emplace(value, value);
+            if (!inserted) {
+                // another thread inserted it while we were trying to: cleanup
+                tracyFree(copy);
+            }
+            memoized = it->second;
+        }
+        assert(str == memoized);
+        return memoized;
+    }
+};
+
+struct SourceLocationMap {
+    static constexpr bool instrument = false;
+
+    // NOTE(marcos): the address of an unordered_map value may become invalid
+    // later on (e.g., during a rehash), so mapping to a pointer is necessary
+    ConcurrentHashMap<std::string_view, tracy::SourceLocationData*> locations;
+
+    ~SourceLocationMap() { /* TODO(marcos): free SourceLocationData* entries */ }
+
+    tracy::SourceLocationData* retrieve(std::string_view function) {
+        ZoneNamed(retrieve, instrument);
+        tracy::SourceLocationData* pSrcLoc = nullptr;
+        locations.fetch(function, pSrcLoc);
+        return pSrcLoc;
+    }
+
+    tracy::SourceLocationData* add(std::string_view function, std::string_view file, int line, uint32_t color=0) {
+        ZoneNamed(emplace, instrument);
+        assert(*function.end() == '\0');
+        assert(*file.end() == '\0');
+        void* bytes = tracyMalloc(sizeof(tracy::SourceLocationData));
+        auto pSrcLoc = new(bytes)tracy::SourceLocationData{ function.data(), TracyFunction, file.data(), (uint32_t)line, color };
+        auto [it, inserted] = locations.emplace(function, pSrcLoc);
+        if (!inserted) {
+            // another thread inserted it while we were trying to: cleanup
+            tracyFree(pSrcLoc); // POD: no destructor to call
+        }
+        assert(it->second != nullptr);
+        return it->second;
+    }
+};
+
+struct SourceLocationLUT {
+    static constexpr bool instrument = false;
+
+    ~SourceLocationLUT() { /* no action needed: no dynamic allocation */ }
+
+    tracy::SourceLocationData runtime [CUpti_runtime_api_trace_cbid::CUPTI_RUNTIME_TRACE_CBID_SIZE] = {};
+    tracy::SourceLocationData driver [CUpti_driver_api_trace_cbid::CUPTI_DRIVER_TRACE_CBID_SIZE] = {};
+
+    tracy::SourceLocationData* retrieve(CUpti_CallbackDomain domain, CUpti_CallbackId cbid, CUpti_CallbackData* apiInfo) {
+        ZoneNamed(retrieve, instrument);
+        tracy::SourceLocationData* pSrcLoc = nullptr;
+        switch (domain) {
+        case CUPTI_CB_DOMAIN_RUNTIME_API :
+            if ((cbid > 0) && (cbid < CUPTI_RUNTIME_TRACE_CBID_SIZE)) {
+                pSrcLoc = &runtime[cbid];
+            }
+            break;
+        case CUPTI_CB_DOMAIN_DRIVER_API :
+            if ((cbid > 0) && (cbid < CUPTI_DRIVER_TRACE_CBID_SIZE)) {
+                pSrcLoc = &driver[cbid];
+            }
+            break;
+        default:
+            break;
+        }
+        if (pSrcLoc->name == nullptr) {
+            const char* function = apiInfo->functionName ? apiInfo->functionName : "cuda???";
+            // cuptiGetCallbackName includes the "version suffix" of the function/cbid
+            //CUPTI_API_CALL(cuptiGetCallbackName(domain, cbid, &function));
+            *pSrcLoc = tracy::SourceLocationData{ function, TracyFunction, TracyFile, TracyLine, 0 };
+        }
+        return pSrcLoc;
+    }
+};
+
+uint32_t tracyTimelineId(uint32_t contextId, uint32_t streamId) {
+    // 0xA7C5 = 42,949 => 42,949 * 100,000 = 4,294,900,000
+    // 4,294,900,000 + 65,535  = 4,294,965,535 < 4,294,967,295 (max uint32)
+    assert(contextId <= 0xA7C5);
+    assert((streamId == CUPTI_INVALID_STREAM_ID) || (streamId < 0xFFFF));
+    uint32_t packed = (contextId * 100'000) + (streamId & 0x0000'FFFF);
+    return packed;
+}
+
+} // unnamed/anonymous namespace
+
+namespace tracy
+{
+    class CUDACtx
+    {
+    public:
+        static CUDACtx* Create() {
+            auto& s = Singleton::Get();
+            std::unique_lock<std::mutex> lock (s.m);
+            if (s.ref_count == 0) {
+                assert(s.ctx == nullptr);
+                s.ctx = new CUDACtx(s.ctx_id);
+                s.ref_count += 1;
+                s.ctx_id = s.ctx->m_tracyGpuContext;
+            }
+            return s.ctx;
+        }
+
+        static void Destroy(CUDACtx* ctx) {
+            auto& s = Singleton::Get();
+            std::unique_lock<std::mutex> lock(s.m);
+            assert(ctx == s.ctx);
+            s.ref_count -= 1;
+            if (s.ref_count == 0) {
+                delete s.ctx;
+                s.ctx = nullptr;
+            }
+        }
+
+        void Collect()
+        {
+            ZoneScoped;
+            CUPTI::FlushActivity();
+        }
+
+        void printStats()
+        {
+            #if TRACY_CUDA_ENABLE_CUDA_CALL_STATS
+            fprintf(stdout, "\nCUDA API stats:\n");
+            {
+                struct Stats { CUpti_CallbackDomain domain; CUpti_CallbackId cbid; int count; };
+                std::vector<Stats> sorted;
+                for (auto&& api : stats.apiCallCount.mapping) {
+                    auto domain = CUpti_CallbackDomain(api.first >> 24);
+                    auto cbid = CUpti_CallbackId(api.first & 0x00'FFFFFF);
+                    int count = api.second;
+                    sorted.emplace_back(Stats{ domain, cbid, count });
+                }
+                std::sort(sorted.begin(), sorted.end(), [](const Stats& x, const Stats& y) { return x.count > y.count; });
+                for (auto&& api : sorted) {
+                    const char* function = "";
+                    CUPTI_API_CALL(cuptiGetCallbackName(api.domain, api.cbid, &function));
+                    printf("- %s : %d\n", function, api.count);
+                }
+            }
+            #endif
+        }
+
+        void StartProfiling()
+        {
+            ZoneScoped;
+            CUPTI::BeginInstrumentation(this);
+        }
+
+        void StopProfiling()
+        {
+            ZoneScoped;
+            CUPTI::EndInstrumentation();
+            printStats();
+        }
+
+        void Name(const char *name, uint16_t len)
+        {
+            auto ptr = (char*)tracyMalloc(len);
+            memcpy(ptr, name, len);
+
+            auto item = Profiler::QueueSerial();
+            tracyMemWrite(item->hdr.type, QueueType::GpuContextName);
+            tracyMemWrite(item->gpuContextNameFat.context, m_tracyGpuContext);
+            tracyMemWrite(item->gpuContextNameFat.ptr, (uint64_t)ptr);
+            tracyMemWrite(item->gpuContextNameFat.size, len);
+            SubmitQueueItem(item);
+        }
+
+        tracy_force_inline void SubmitQueueItem(tracy::QueueItem *item)
+        {
+#ifdef TRACY_ON_DEMAND
+            GetProfiler().DeferItem(*item);
+#endif
+            Profiler::QueueSerialFinish();
+        }
+
+        static void QueryTimestamps(TracyTimestamp& tTracy, CUptiTimestamp& tCUpti) {
+            TracyTimestamp tTracy1 = tracyGetTimestamp();
+            CUPTI_API_CALL(cuptiGetTimestamp(&tCUpti));
+            TracyTimestamp tTracy2 = tracyGetTimestamp();
+            // NOTE(marcos): giving more weight to 'tTracy2'
+            tTracy = (3*tTracy1 + 5*tTracy2) / 8;
+        }
+
+        // NOTE(marcos): recalibration is 'static' since Tracy and CUPTI timestamps
+        // are "global" across all contexts; that said, each Tracy GPU context needs
+        // its own GpuCalibration message, but for now there's just a singleton context.
+        void Recalibrate() {
+            ZoneScoped;
+            // NOTE(marcos): only one thread should do the calibration, but there's
+            // no good reason to block threads that also trying to do the same
+            static std::mutex m;
+            if (!m.try_lock())
+                return;
+            std::unique_lock<std::mutex> lock (m, std::adopt_lock);
+            ZoneNamedNC(zone, "tracy::CUDACtx::Recalibrate[effective]", tracy::Color::Goldenrod, true);
+            TracyTimestamp tTracy;
+            CUptiTimestamp tCUpti;
+            QueryTimestamps(tTracy, tCUpti);
+            #if TRACY_CUDA_CALIBRATED_CONTEXT
+            static CUptiTimestamp prevCUptiTime = tCUpti;
+            int64_t deltaTicksCUpti = tCUpti - prevCUptiTime;
+            if (deltaTicksCUpti > 0) {
+                prevCUptiTime = tCUpti;
+                auto* item = Profiler::QueueSerial();
+                tracyMemWrite(item->hdr.type, QueueType::GpuCalibration);
+                tracyMemWrite(item->gpuCalibration.gpuTime, (int64_t)tCUpti);
+                tracyMemWrite(item->gpuCalibration.cpuTime, tTracy);
+                tracyMemWrite(item->gpuCalibration.cpuDelta, deltaTicksCUpti);
+                tracyMemWrite(item->gpuCalibration.context, m_tracyGpuContext);
+                Profiler::QueueSerialFinish();
+            }
+            #endif
+            // NOTE(marcos): update linear regression incrementally, which will refine
+            // the estimation of Tracy timestamps (Y) from CUpti timestamps (X)
+            static IncrementalRegression model;
+            model.addSample(double(tCUpti), double(tTracy));
+            // NOTE(marcos): using orthogonal regression because the independet variable
+            // (X: CUpti timestamps) measurements are also imprecise
+            getCachedRegressionParameters() = model.orthogonal();
+        }
+
+    protected:
+        void EmitGpuZone(TracyTimestamp apiStart, TracyTimestamp apiEnd,
+            CUptiTimestamp gpuStart, CUptiTimestamp gpuEnd,
+            const tracy::SourceLocationData* pSrcLoc,
+            uint32_t cudaContextId, uint32_t cudaStreamId) {
+            //uint32_t timelineId = tracy::GetThreadHandle();
+            uint32_t timelineId = tracyTimelineId(cudaContextId, cudaStreamId);
+            uint16_t queryId = m_queryIdGen.fetch_add(2);
+            tracyAnnounceGpuTimestamp(apiStart, apiEnd, queryId, m_tracyGpuContext, pSrcLoc, timelineId);
+            tracySubmitGpuTimestamp(gpuStart, gpuEnd, queryId, m_tracyGpuContext);
+        }
+
+        void OnEventsProcessed() {
+            Recalibrate();
+        }
+
+        struct CUPTI {
+        static void CUPTIAPI OnBufferRequested(uint8_t **buffer, size_t *size, size_t *maxNumRecords)
+        {
+            ZoneScoped;
+            // TODO(marcos): avoid malloc and instead suballocate from a large circular buffer;
+            // according to the CUPTI documentation: "To minimize profiling overhead the client
+            // should return as quickly as possible from these callbacks."
+            *size = 1 * 1024*1024; // 1MB
+            *buffer = (uint8_t*)tracyMalloc(*size);
+            assert(*buffer != nullptr);
+            FlushActivityAsync();
+        }
+
+        static void CUPTIAPI OnBufferCompleted(CUcontext ctx, uint32_t streamId, uint8_t* buffer, size_t size, size_t validSize)
+        {
+            // CUDA 6.0 onwards: all buffers from this callback are "global" buffers
+            // (i.e. there is no context/stream specific buffer; ctx is always NULL)
+            ZoneScoped;
+            tracy::SetThreadName("NVIDIA CUPTI Worker");
+            CUptiResult status;
+            CUpti_Activity* record = nullptr;
+            while ((status = cuptiActivityGetNextRecord(buffer, validSize, &record)) == CUPTI_SUCCESS) {
+                DoProcessDeviceEvent(record);
+            }
+            if (status != CUPTI_ERROR_MAX_LIMIT_REACHED) {
+                CUptiCallChecked(status, "cuptiActivityGetNextRecord", TracyFile, TracyLine);
+            }
+            size_t dropped = 0;
+            CUPTI_API_CALL(cuptiActivityGetNumDroppedRecords(ctx, streamId, &dropped));
+            assert(dropped == 0);
+            tracyFree(buffer);
+            PersistentState::Get().profilerHost->OnEventsProcessed();
+        }
+
+        // correlationID -> [CPU start time, CPU end time, CUPTI start time]
+        using CorrelationID = uint32_t;
+        struct APICallInfo { TracyTimestamp start = 0, end = 0; CUptiTimestamp cupti = CUPTI_TIMESTAMP_UNKNOWN; CUDACtx* host = nullptr; };
+
+        static void CUPTIAPI OnCallbackAPI(
+            void* userdata,
+            CUpti_CallbackDomain domain,
+            CUpti_CallbackId cbid,
+            const void* cbdata)
+        {
+            static constexpr bool instrument = false;
+
+            TracyTimestamp apiCallStartTime = tracyGetTimestamp();
+            CUDACtx* profilerHost = (CUDACtx*)userdata;
+
+            switch (domain) {
+            case CUPTI_CB_DOMAIN_RUNTIME_API:
+            case CUPTI_CB_DOMAIN_DRIVER_API:
+                break;
+            case CUPTI_CB_DOMAIN_RESOURCE: {
+                // match 'callbackId' with CUpti_CallbackIdResource
+                // interpret 'cbdata' as CUpti_ResourceData,
+                //                 or as CUpti_ModuleResourceData,
+                //                 or as CUpti_GraphData,
+                //                 or as CUpti_StreamAttrData,
+                //                 or as ... (what else?)
+                return;
+            }
+            case CUPTI_CB_DOMAIN_SYNCHRONIZE: {
+                // match 'callbackId' with CUpti_CallbackIdSync
+                // interpret 'cbdata' as CUpti_SynchronizeData
+                return;
+            }
+            case CUPTI_CB_DOMAIN_STATE: {
+                // match 'callbackId' with CUpti_CallbackIdState
+                // interpret 'cbdata' as CUpti_StateData
+                return;
+            }
+            case CUPTI_CB_DOMAIN_NVTX: {
+                // match 'callbackId' with CUpti_nvtx_api_trace_cbid
+                // interpret 'cbdata' as CUpti_NvtxData
+                return;
+            }
+            case CUPTI_CB_DOMAIN_FORCE_INT:
+                // NOTE(marcos): the "FORCE_INT" values in CUPTI enums exist only to
+                // force the enum to have a specific representation (signed 32bits)
+            case CUPTI_CB_DOMAIN_INVALID:
+            default:
+                // TODO(marcos): unexpected error!
+                return;
+            }
+    
+            // if we reached this point, then we are in the (runtime or driver) API domain
+            CUpti_CallbackData* apiInfo = (CUpti_CallbackData*)cbdata;
+
+            // Emit the Tracy 'ZoneBegin' message upon entering the API call
+            // TODO(marcos): a RAII object could be useful here...
+            if (apiInfo->callbackSite == CUPTI_API_ENTER) {
+                #if TRACY_CUDA_ENABLE_CUDA_CALL_STATS
+                ctx->stats.update(domain, cbid);
+                #endif
+
+                auto& cudaCallSourceLocation = PersistentState::Get().cudaCallSourceLocation;
+                auto pSrcLoc = cudaCallSourceLocation.retrieve(domain, cbid, apiInfo);
+
+                // HACK(marcos): the SourceLocationLUT::retrieve zone (above) should
+                // not be emitted before its enclosing zone (below) actually begins,
+                // so we delay the beginning of the enclosing zone to "unstack" them
+                if (SourceLocationLUT::instrument)
+                    apiCallStartTime = tracyGetTimestamp();
+                tracyZoneBegin(apiCallStartTime, pSrcLoc);
+            }
+
+            if (apiInfo->callbackSite == CUPTI_API_ENTER) {
+                ZoneNamedN(enter, "tracy::CUDACtx::OnCUptiCallback[enter]", instrument);
+                // Track API calls that generate device activity:
+                bool trackDeviceActivity = false;
+                CUstream hStream = nullptr;
+                if (domain == CUPTI_CB_DOMAIN_RUNTIME_API) {
+                    #define GET_STREAM_FUNC(Params, field) [](CUpti_CallbackData* api) { return ((Params*)api->functionParams)->field; }
+                    #define NON_STREAM_FUNC() [](CUpti_CallbackData*) { return cudaStream_t(nullptr); }
+                    static std::unordered_map<CUpti_runtime_api_trace_cbid, cudaStream_t(*)(CUpti_CallbackData*)> cbidRuntimeTrackers = {
+                        // Runtime: Kernel
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000,          GET_STREAM_FUNC(cudaLaunchKernel_v7000_params, stream) },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000,     GET_STREAM_FUNC(cudaLaunchKernel_ptsz_v7000_params, stream) },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,      GET_STREAM_FUNC(cudaLaunchKernelExC_v11060_params, config->stream) },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060, GET_STREAM_FUNC(cudaLaunchKernelExC_ptsz_v11060_params, config->stream) },
+                        // Runtime: Memory
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaMalloc_v3020, NON_STREAM_FUNC() },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaFree_v3020,   NON_STREAM_FUNC() },
+                        // Runtime: Memcpy
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020,      NON_STREAM_FUNC() },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaMemcpyAsync_v3020, GET_STREAM_FUNC(cudaMemcpyAsync_v3020_params, stream) },
+                        // Runtime: Memset
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaMemset_v3020,      NON_STREAM_FUNC() },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaMemsetAsync_v3020, GET_STREAM_FUNC(cudaMemsetAsync_v3020_params, stream) },
+                        // Runtime: Synchronization
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaStreamSynchronize_v3020, NON_STREAM_FUNC() },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaEventSynchronize_v3020,  NON_STREAM_FUNC() },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaEventQuery_v3020,        NON_STREAM_FUNC() },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020,   NON_STREAM_FUNC() },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020, NON_STREAM_FUNC() },
+                    };
+                    #undef NON_STREAM_FUNC
+                    #undef GET_STREAM_FUNC
+                    auto it = cbidRuntimeTrackers.find(CUpti_runtime_api_trace_cbid(cbid));
+                    if (it != cbidRuntimeTrackers.end()) {
+                        trackDeviceActivity = true;
+                        hStream = (CUstream)it->second(apiInfo);
+                    }
+                }
+                if (domain == CUPTI_CB_DOMAIN_DRIVER_API) {
+                    #define GET_STREAM_FUNC(Params, field) [](CUpti_CallbackData* api) { return ((Params*)api->functionParams)->field; }
+                    #define NON_STREAM_FUNC() [](CUpti_CallbackData*) { return CUstream(nullptr); }
+                    static std::unordered_map<CUpti_driver_api_trace_cbid, CUstream(*)(CUpti_CallbackData*)> cbidDriverTrackers = {
+                        // Driver: Kernel
+                        { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel,        GET_STREAM_FUNC(cuLaunchKernel_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz,   GET_STREAM_FUNC(cuLaunchKernel_ptsz_params, hStream)} ,
+                        { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx,      GET_STREAM_FUNC(cuLaunchKernelEx_params, config->hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz, GET_STREAM_FUNC(cuLaunchKernelEx_params, config->hStream) },
+                    };
+                    #undef NON_STREAM_FUNC
+                    #undef GET_STREAM_FUNC
+                    auto it = cbidDriverTrackers.find(CUpti_driver_api_trace_cbid(cbid));
+                    if (it != cbidDriverTrackers.end()) {
+                        trackDeviceActivity = true;
+                        hStream = it->second(apiInfo);
+                    }
+                }
+                if (trackDeviceActivity) {
+                    // NOTE(marcos): we should NOT track if the stream is being captured
+                    CUstreamCaptureStatus status = {};
+                    DRIVER_API_CALL(cuStreamIsCapturing(hStream, &status));
+                    trackDeviceActivity = !(status == CU_STREAM_CAPTURE_STATUS_ACTIVE);
+                }
+                if (trackDeviceActivity) {
+                    CUptiTimestamp tgpu;
+                    // TODO(marcos): do a "reverse-estimate" to obtain CUpti time from Tracy time instead?
+                    CUPTI_API_CALL(cuptiGetTimestamp(&tgpu));
+                    auto& cudaCallSiteInfo = PersistentState::Get().cudaCallSiteInfo;
+                    cudaCallSiteInfo.emplace(apiInfo->correlationId, APICallInfo{ apiCallStartTime, apiCallStartTime, tgpu, profilerHost });
+                }
+                auto& entryFlags = *apiInfo->correlationData;
+                assert(entryFlags == 0);
+                entryFlags |= trackDeviceActivity ? 0x8000 : 0;
+            }
+
+            if (apiInfo->callbackSite == CUPTI_API_EXIT) {
+                APICallInfo* pApiInterval = [](CUpti_CallbackData* apiInfo) {
+                    ZoneNamedN(exit, "tracy::CUDACtx::OnCUptiCallback[exit]", instrument);
+                    auto entryFlags = *apiInfo->correlationData;
+                    bool trackDeviceActivity = (entryFlags & 0x8000) != 0;
+                    if (trackDeviceActivity) {
+                        auto& cudaCallSiteInfo = PersistentState::Get().cudaCallSiteInfo;
+                        auto it = cudaCallSiteInfo.find(apiInfo->correlationId);
+                        if (it != cudaCallSiteInfo.end()) {
+                            // WARN(marcos): leaking the address of a hash-map value could spell trouble
+                            return &it->second;
+                        }
+                    }
+                    // NOTE(marcos): this can happen if the GPU activity completes
+                    // before the CUDA function that enqueued it returns (e.g., sync)
+                    static APICallInfo sentinel;
+                    return &sentinel;
+                }(apiInfo);
+                pApiInterval->end = tracyGetTimestamp();
+                tracyZoneEnd(pApiInterval->end);
+            }
+        }
+
+        static bool matchActivityToAPICall(uint32_t correlationId, APICallInfo& apiCallInfo) {
+            static constexpr bool instrument = false;
+            ZoneNamed(match, instrument);
+            auto& cudaCallSiteInfo = PersistentState::Get().cudaCallSiteInfo;
+            if (!cudaCallSiteInfo.fetch(correlationId, apiCallInfo)) {
+                return false;
+            }
+            cudaCallSiteInfo.erase(correlationId);
+            assert(apiCallInfo.host != nullptr);
+            return true;
+        }
+
+        static void matchError(uint32_t correlationId, const char* kind) {
+            char msg [128];
+            snprintf(msg, sizeof(msg), "ERROR: device activity '%s' has no matching CUDA API call (id=%u).", kind, correlationId);
+            TracyMessageC(msg, strlen(msg), tracy::Color::Tomato);
+        }
+
+        static std::string extractActualName(char** name){
+            //If name does not start with number, return empty string
+            if (!isdigit(**name))
+            {
+                return std::string();
+            }
+            // Assuming name starts with number followed by actual name
+            std::string actualName;
+            char* currStr = *name;
+            int num = 0;
+            while (*currStr >= '0' && *currStr <= '9')
+            {
+                num = num * 10 + (*currStr - '0');
+                currStr++;
+            }
+
+            // Return the string start at currStr ends at num
+            actualName = std::string(currStr, num);
+            // check if actualName starts with _GLOBAL__N__
+            if (actualName.rfind("_GLOBAL__N__", 0) == 0)
+            {
+                // _GLOBAL__N__ with an id stands for anonymous namespace
+                actualName = std::string("(anonymous_namespace)");
+            }
+
+            *name = currStr + num;
+            return actualName;
+        }
+
+        static std::string extractActualNameNested(const char* demangledName)
+        {
+            ZoneNamedN(demangle, "demangle_kernel", false);
+            //If name does not start with _Z, return a new std::string with original name
+            if (demangledName[0] != '_' || demangledName[1] != 'Z')
+            {
+                return std::string(demangledName);
+            }
+            std::string actualName;
+            char* currStr = (char*)demangledName + 2;
+
+            if (*currStr == 'N')
+            {
+                currStr++;
+                // extract actual name from nested name
+                std::string nestedName = extractActualName(&currStr);
+                actualName += nestedName;
+                while (1)
+                {
+                    //Loop until nested name is empty
+                    nestedName = extractActualName(&currStr);
+                    if (nestedName.empty())
+                    {
+                        break;
+                    }
+                    actualName += "::" + nestedName;
+                }
+            } else
+            {
+                actualName = extractActualName(&currStr);
+            }
+            return actualName;
+        }
+
+        static tracy::SourceLocationData* getKernelSourceLocation(const char* kernelName)
+        {
+            auto& kernelSrcLoc = PersistentState::Get().kernelSrcLoc;
+            std::string_view demangledName;
+        #ifndef _MSC_VER
+            // TODO(marcos): extractActualNameNested is the main bottleneck right now;
+            // we need a specialized StringTable mapping from "peristent" kernel names
+            // (const char*/uintptr_t) to memoized, lazily initialized demangled names
+            auto& demangledNameTable = PersistentState::Get().demangledNameTable;
+            std::string demangled = extractActualNameNested(kernelName);
+            demangledName = demangledNameTable[demangled];
+        #else
+            demangledName = kernelName;
+        #endif
+            auto pSrcLoc = kernelSrcLoc.retrieve(demangledName);
+            if (pSrcLoc == nullptr) {
+                pSrcLoc = kernelSrcLoc.add(demangledName, TracyFile, TracyLine);
+            }
+            return pSrcLoc;
+        }
+
+        static void DoProcessDeviceEvent(CUpti_Activity *record)
+        {
+            static constexpr bool instrument = false;
+            ZoneNamed(activity, instrument);
+
+            switch (record->kind)
+            {
+            case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL:
+            {   
+                ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[kernel]", instrument);
+                CUpti_ActivityKernel9* kernel9 = (CUpti_ActivityKernel9*) record;
+                APICallInfo apiCall;
+                if (!matchActivityToAPICall(kernel9->correlationId, apiCall)) {
+                    return matchError(kernel9->correlationId, "KERNEL");
+                }
+                apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, kernel9->start, kernel9->end, getKernelSourceLocation(kernel9->name), kernel9->contextId, kernel9->streamId);
+                auto latency_ms = (kernel9->start - apiCall.cupti) / 1'000'000.0;
+                tracyPlotBlip("Kernel Latency (ms)", kernel9->start, latency_ms);
+                break;
+            }
+
+            case CUPTI_ACTIVITY_KIND_MEMCPY:
+            {
+                ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[memcpy]", instrument);
+                CUpti_ActivityMemcpy5* memcpy5 = (CUpti_ActivityMemcpy5*) record;
+                APICallInfo apiCall;
+                if (!matchActivityToAPICall(memcpy5->correlationId, apiCall)) {
+                    return matchError(memcpy5->correlationId, "MEMCPY");
+                }
+                static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemcpy { "CUDA::memcpy", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
+                apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memcpy5->start, memcpy5->end, &TracyCUPTISrcLocDeviceMemcpy, memcpy5->contextId, memcpy5->streamId);
+                static constexpr const char* graph_name = "CUDA Memory Copy";
+                tracyEmitMemAlloc(graph_name, (void*)(uintptr_t)memcpy5->correlationId, memcpy5->bytes, memcpy5->start);
+                tracyEmitMemFree (graph_name, (void*)(uintptr_t)memcpy5->correlationId,                 memcpy5->end);
+                break;
+            }
+
+            case CUPTI_ACTIVITY_KIND_MEMSET:
+            {
+                ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[memset]", instrument);
+                CUpti_ActivityMemset4* memset4 = (CUpti_ActivityMemset4*) record;
+                APICallInfo apiCall;
+                if (!matchActivityToAPICall(memset4->correlationId, apiCall)) {
+                    return matchError(memset4->correlationId, "MEMSET");
+                }
+                static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemset { "CUDA::memset", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
+                apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memset4->start, memset4->end, &TracyCUPTISrcLocDeviceMemset, memset4->contextId, memset4->streamId);
+                static constexpr const char* graph_name = "CUDA Memory Set";
+                tracyEmitMemAlloc(graph_name, (void*)(uintptr_t)memset4->correlationId, memset4->bytes, memset4->start);
+                tracyEmitMemFree (graph_name, (void*)(uintptr_t)memset4->correlationId,                 memset4->end);
+                break;
+            }
+
+            case CUPTI_ACTIVITY_KIND_SYNCHRONIZATION:
+            {
+                ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[sync]", instrument);
+                CUpti_ActivitySynchronization* synchronization = (CUpti_ActivitySynchronization*) record;
+                APICallInfo apiCall;
+                if (!matchActivityToAPICall(synchronization->correlationId, apiCall)) {
+                    return matchError(synchronization->correlationId, "SYNCHRONIZATION");
+                }
+                // NOTE(marcos): synchronization can happen at different levels/objects:
+                // a. on the entire context : cuCtxSynchronize()    -> timeline(ctx,0)
+                // b. on a specific stream  : cuStreamSynchronize() -> timeline(ctx,stream)
+                // c. on a specific event   : cuEventSynchronize()  -> timeline(ctx,0xffff)
+                static constexpr tracy::SourceLocationData TracyCUPTISrcLocContextSynchronization { "CUDA::Context::sync", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Magenta };
+                auto* pSrcLoc = &TracyCUPTISrcLocContextSynchronization;
+                uint32_t cudaContextId = synchronization->contextId;
+                uint32_t cudaStreamId = 0;
+                if (synchronization->streamId != CUPTI_SYNCHRONIZATION_INVALID_VALUE) {
+                    static constexpr tracy::SourceLocationData TracyCUPTISrcLocStreamSynchronization{ "CUDA::Stream::sync", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Magenta3 };
+                    pSrcLoc = &TracyCUPTISrcLocStreamSynchronization;
+                    cudaStreamId = synchronization->streamId;
+                }
+                if (synchronization->cudaEventId != CUPTI_SYNCHRONIZATION_INVALID_VALUE) {
+                    static constexpr tracy::SourceLocationData TracyCUPTISrcLocEventSynchronization{ "CUDA::Event::sync", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Magenta4 };
+                    pSrcLoc = &TracyCUPTISrcLocEventSynchronization;
+                    cudaStreamId = 0xFFFFFFFF;
+                    // TODO(marcos): CUpti_ActivitySynchronization2 introduces a new
+                    // field 'cudaEventSyncId' which complements 'cudaEventId'
+                }
+                apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, synchronization->start, synchronization->end, pSrcLoc, cudaContextId, cudaStreamId);
+                static constexpr const char* graph_name = "CUDA Synchronization";
+                tracyEmitMemAlloc(graph_name, (void*)(uintptr_t)synchronization->correlationId, 1, synchronization->start);
+                tracyEmitMemFree (graph_name, (void*)(uintptr_t)synchronization->correlationId,    synchronization->end);
+                break;
+            }
+            case CUPTI_ACTIVITY_KIND_MEMORY2:
+            {
+                ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[malloc/free]", instrument);
+                CUpti_ActivityMemory3* memory3 = (CUpti_ActivityMemory3*)record;
+                APICallInfo apiCall;
+                if (!matchActivityToAPICall(memory3->correlationId, apiCall)) {
+                    return matchError(memory3->correlationId, "MEMORY");
+                }
+                static constexpr const char* graph_name = "CUDA Memory Allocation";
+                if (memory3->memoryOperationType == CUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_ALLOCATION){
+                    auto& memAllocAddress = PersistentState::Get().memAllocAddress;
+                    memAllocAddress[memory3->address] = 1;
+                    tracyEmitMemAlloc(graph_name, (void*)memory3->address, memory3->bytes, memory3->timestamp);
+                }
+                else if (memory3->memoryOperationType == CUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_RELEASE){
+                    auto& memAllocAddress = PersistentState::Get().memAllocAddress;
+                    int dontCare;
+                    if (!memAllocAddress.fetch(memory3->address, dontCare)){
+                        // Note(Frank): This is a hack to handle the case where the memory allocation
+                        // corresponds to the memory release is not found.
+                        // This can happen when the memory is allocated when profiling is not enabled.
+                        matchError(memory3->correlationId, "MEMORY/RELEASE");
+                        tracyEmitMemAlloc(graph_name, (void*)memory3->address, memory3->bytes, memory3->timestamp);
+                    } else {
+                        memAllocAddress.erase(memory3->address);
+                    }
+                    tracyEmitMemFree(graph_name, (void*)memory3->address, memory3->timestamp);
+                }
+                break;
+            }
+            case CUPTI_ACTIVITY_KIND_CUDA_EVENT :
+            {
+                // NOTE(marcos): a byproduct of CUPTI_ACTIVITY_KIND_SYNCHRONIZATION
+                // (I think this is related to cudaEvent*() API calls)
+                CUpti_ActivityCudaEvent2* event = (CUpti_ActivityCudaEvent2*)record;
+                UNREFERENCED(event);
+                break;
+            }
+            default:
+            {
+                char buffer[64];
+                snprintf(buffer, sizeof(buffer), "Unknown activity record (kind is %d)", record->kind);
+                TracyMessageC(buffer, strlen(buffer), tracy::Color::Crimson);
+                break;
+            }
+            }
+        }
+
+        static constexpr CUpti_CallbackDomain domains[] = {
+            CUPTI_CB_DOMAIN_RUNTIME_API,
+            CUPTI_CB_DOMAIN_DRIVER_API,
+            //CUPTI_CB_DOMAIN_RESOURCE,
+            //CUPTI_CB_DOMAIN_SYNCHRONIZE,
+            //CUPTI_CB_DOMAIN_NVTX,
+            //CUPTI_CB_DOMAIN_STATE
+        };
+
+        static constexpr CUpti_ActivityKind activities[] = {
+            //CUPTI_ACTIVITY_KIND_KERNEL, // mutually exclusive with CONCURRENT_KERNEL
+            CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL,
+            CUPTI_ACTIVITY_KIND_MEMCPY,
+            CUPTI_ACTIVITY_KIND_MEMSET,
+            CUPTI_ACTIVITY_KIND_SYNCHRONIZATION,
+            CUPTI_ACTIVITY_KIND_MEMORY2,
+            //CUPTI_ACTIVITY_KIND_MEMCPY2,
+            //CUPTI_ACTIVITY_KIND_OVERHEAD,
+            //CUPTI_ACTIVITY_KIND_INTERNAL_LAUNCH_API,
+            //CUPTI_ACTIVITY_KIND_RUNTIME,
+            //CUPTI_ACTIVITY_KIND_DRIVER,
+        };
+
+        static void BeginInstrumentation(CUDACtx* profilerHost) {
+            auto& currentProfilerHost = PersistentState::Get().profilerHost;
+            if (currentProfilerHost != nullptr) {
+                return;
+            }
+            currentProfilerHost = profilerHost;
+
+            // NOTE(frank): full-stop synchronization to ensure we only handle
+            // CUDA API calls and device activities that happens past this point
+            cudaDeviceSynchronize();
+
+            auto& subscriber = PersistentState::Get().subscriber;
+            CUPTI_API_CALL(cuptiSubscribe(&subscriber, CUPTI::OnCallbackAPI, profilerHost));
+            CUPTI_API_CALL(cuptiActivityRegisterCallbacks(CUPTI::OnBufferRequested, CUPTI::OnBufferCompleted));
+            for (auto domain : domains) {
+                CUPTI_API_CALL(cuptiEnableDomain(uint32_t(true), subscriber, domain));
+            }
+            for (auto activity : activities) {
+                CUPTI_API_CALL(cuptiActivityEnable(activity));
+            }
+
+            #if TRACY_CUDA_ENABLE_COLLECTOR_THREAD
+            auto& collector = PersistentState::Get().collector;
+            collector.period = 160;
+            collector.signal.notify_one();
+            #endif
+        }
+
+        static void EndInstrumentation() {
+            auto& currentProfilerHost = PersistentState::Get().profilerHost;
+            if (currentProfilerHost == nullptr) {
+                return;
+            }
+
+            // NOTE(frank): full-stop synchronization to ensure we catch
+            // and drain all the activities that has been tracked up to now.
+            cudaDeviceSynchronize();
+
+            FlushActivity();
+
+            auto& subscriber = PersistentState::Get().subscriber;
+            for (auto activity : activities) {
+                CUPTI_API_CALL(cuptiActivityDisable(activity));
+            }
+            for (auto domain : domains) {
+                CUPTI_API_CALL(cuptiEnableDomain(uint32_t(false), subscriber, domain));
+            }
+            // TODO(marcos): is here a counterpart for 'cuptiActivityRegisterCallbacks()'?
+            CUPTI_API_CALL(cuptiUnsubscribe(subscriber));
+
+            #if TRACY_CUDA_ENABLE_COLLECTOR_THREAD
+            auto& collector = PersistentState::Get().collector;
+            collector.period = ~uint32_t(0);
+            collector.signal.notify_one();
+            #endif
+
+            currentProfilerHost = nullptr;
+        }
+
+        static void FlushActivity()
+        {
+            // NOTE(marcos): only one thread should do the collection at any given time,
+            // but there's no reason to block threads that are also trying to do the same
+            static std::mutex m;
+            if (!m.try_lock())
+                return;
+            std::unique_lock<std::mutex> lock (m, std::adopt_lock);
+            ZoneNamedNC(zone, "cuptiActivityFlushAll", tracy::Color::Red4, true);
+            CUPTI_API_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_NONE));
+        }
+
+        #if TRACY_CUDA_ENABLE_COLLECTOR_THREAD
+        // WARN(marcos): technically, CUPTI already offers async flushing of
+        // activity records through cuptiActivityFlushPeriod(), but I haven't
+        // had much luck getting reliable, consistent delivery with it...
+        struct Collector {
+            std::atomic<bool> running = true;
+            volatile uint32_t period = ~uint32_t(0);
+            std::mutex mtx;
+            std::condition_variable signal;
+            std::thread thread = std::thread(
+                [this]() {
+                    tracy::SetThreadName("Tracy CUDA Collector");
+                    atexit([]() {
+                        auto& collector = CUPTI::PersistentState::Get().collector;
+                        collector.running = false;
+                        collector.signal.notify_one();
+                        collector.thread.join();
+                    });
+                    while (running) {
+                        {
+                            std::unique_lock<std::mutex> lock(mtx);
+                            signal.wait_for(lock, std::chrono::milliseconds(period));
+                        }
+                        FlushActivity();
+                    }
+                }
+            );
+        };
+        #endif
+
+        static void FlushActivityAsync()
+        {
+            #if TRACY_CUDA_ENABLE_COLLECTOR_THREAD
+            ZoneScoped;
+            auto& collector = PersistentState::Get().collector;
+            collector.signal.notify_one();
+            #endif
+        }
+
+        struct PersistentState {
+            // NOTE(marcos): these objects must remain in memory past the application
+            // returning from main() because the Tracy client worker thread may still
+            // be responding to string/source-location requests from the server
+            SourceLocationMap kernelSrcLoc;
+            StringTable demangledNameTable;
+            SourceLocationLUT cudaCallSourceLocation;
+
+            // NOTE(marcos): these objects do not need to persist, but their relative
+            // footprint is trivial enough that we don't care if we let them leak
+            ConcurrentHashMap<CorrelationID, APICallInfo> cudaCallSiteInfo;
+            ConcurrentHashMap<uintptr_t, int> memAllocAddress;
+            CUpti_SubscriberHandle subscriber = {};
+            CUDACtx* profilerHost = nullptr;
+
+            Collector collector;
+
+            static PersistentState& Get() {
+                static PersistentState& persistent = *(new PersistentState());
+                return persistent;
+            }
+        };
+
+        };
+
+        CUDACtx(uint8_t gpuContextID = 255)
+        {
+            ZoneScoped;
+
+            if (gpuContextID != 255) {
+                m_tracyGpuContext = gpuContextID;
+                return;
+            }
+
+            m_tracyGpuContext = GetGpuCtxCounter().fetch_add(1, std::memory_order_relaxed);
+            assert(m_tracyGpuContext != 255);
+
+            TracyTimestamp tTracy;
+            CUptiTimestamp tCUpti;
+            QueryTimestamps(tTracy, tCUpti);
+
+            // Announce to Tracy about a new GPU context/timeline:
+            auto item = Profiler::QueueSerial();
+            tracyMemWrite(item->hdr.type, QueueType::GpuNewContext);
+            tracyMemWrite(item->gpuNewContext.cpuTime, tTracy);
+            tracyMemWrite(item->gpuNewContext.gpuTime, (int64_t)tCUpti); // TODO: Be more careful about this cast
+            tracyMemWrite(item->gpuNewContext.thread, (uint32_t)0);
+            tracyMemWrite(item->gpuNewContext.period, 1.0f);
+            tracyMemWrite(item->gpuNewContext.type, GpuContextType::CUDA);
+            tracyMemWrite(item->gpuNewContext.context, m_tracyGpuContext);
+            #if TRACY_CUDA_CALIBRATED_CONTEXT
+            tracyMemWrite(item->gpuNewContext.flags, GpuContextCalibration);
+            #else
+            tracyMemWrite(item->gpuNewContext.flags, tracy::GpuContextFlags(0));
+            #endif
+            Profiler::QueueSerialFinish();
+
+            constexpr const char* tracyCtxName = "CUDA GPU/Device Activity";
+            this->Name(tracyCtxName, uint16_t(strlen(tracyCtxName)));
+
+            // NOTE(marcos): a few rounds of calibation amorthized over 1 second
+            // in order to get a meaningful linear regression estimator
+            Recalibrate();
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            Recalibrate();
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            Recalibrate();
+            std::this_thread::sleep_for(std::chrono::milliseconds(300));
+            Recalibrate();
+            std::this_thread::sleep_for(std::chrono::milliseconds(400));
+            Recalibrate();
+        }
+
+        ~CUDACtx()
+        {
+            ZoneScoped;
+        }
+
+        struct Singleton {
+            CUDACtx* ctx = nullptr;
+            std::mutex m;
+            int ref_count = 0;
+            uint8_t ctx_id = 255;
+            static Singleton& Get() {
+                static Singleton singleton;
+                return singleton;
+            }
+        };
+
+        #if TRACY_CUDA_ENABLE_CUDA_CALL_STATS
+        ProfilerStats stats = {};
+        #endif
+
+        uint8_t m_tracyGpuContext = 255;
+        static constexpr size_t cacheline = 64;
+        alignas(cacheline) std::atomic<uint16_t> m_queryIdGen = 0;
+    };
+
+}
+
+#define TracyCUDAContext() tracy::CUDACtx::Create()
+#define TracyCUDAContextDestroy(ctx) tracy::CUDACtx::Destroy(ctx)
+#define TracyCUDAContextName(ctx, name, size) ctx->Name(name, size)
+
+#define TracyCUDAStartProfiling(ctx) ctx->StartProfiling()
+#define TracyCUDAStopProfiling(ctx) ctx->StopProfiling()
+
+#define TracyCUDACollect(ctx) ctx->Collect()
+
+#endif
+
+#endif

--- a/tracy-client-sys/tracy/tracy/TracyD3D12.hpp
+++ b/tracy-client-sys/tracy/tracy/TracyD3D12.hpp
@@ -385,7 +385,7 @@ namespace tracy
             WriteQueueItem(item, QueueType::GpuZoneBeginSerial, reinterpret_cast<uint64_t>(srcLocation));
         }
 
-        tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, ID3D12GraphicsCommandList* cmdList, const SourceLocationData* srcLocation, int depth, bool active)
+        tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, ID3D12GraphicsCommandList* cmdList, const SourceLocationData* srcLocation, int32_t depth, bool active)
             : D3D12ZoneScope(ctx, cmdList, active)
         {
             if (!m_active) return;
@@ -405,7 +405,7 @@ namespace tracy
             WriteQueueItem(item, QueueType::GpuZoneBeginAllocSrcLocSerial, sourceLocation);
         }
 
-        tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, ID3D12GraphicsCommandList* cmdList, int depth, bool active)
+        tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, ID3D12GraphicsCommandList* cmdList, int32_t depth, bool active)
             : D3D12ZoneScope(ctx, cmdList, active)
         {
             if (!m_active) return;

--- a/tracy-client-sys/tracy/tracy/TracyMetal.hmm
+++ b/tracy-client-sys/tracy/tracy/TracyMetal.hmm
@@ -1,0 +1,644 @@
+#ifndef __TRACYMETAL_HMM__
+#define __TRACYMETAL_HMM__
+
+/* This file implements a Metal API back-end for Tracy (it has only been tested on Apple
+   Silicon devices, but it should also work on Intel-based Macs and older iOS devices).
+   The Metal back-end in Tracy operates differently than other GPU back-ends like Vulkan,
+   Direct3D and OpenGL. Specifically, TracyMetalZone() must be placed around the site where
+   a command encoder is created. This is because not all hardware supports timestamps at
+   command granularity, and can only provide timestamps around an entire command encoder.
+   This accommodates for all tiers of hardware; in the future, variants of TracyMetalZone()
+   will be added to support the habitual command-level granularity of Tracy GPU back-ends.
+   Metal also imposes a few restrictions that make the process of requesting and collecting
+   queries more complicated in Tracy:
+   a) timestamp query buffers are limited to 4096 queries (32KB, where each query is 8 bytes)
+   b) when a timestamp query buffer is created, Metal initializes all timestamps with zeroes,
+      and there's no way to reset them back to zero after timestamps get resolved; the only
+      way to clear the timestamps is by allocating a new timestamp query buffer
+   c) if a command encoder records no commands and its corresponding command buffer ends up
+      committed to the command queue, Metal will "optimize-away" the encoder along with any
+      timestamp queries associated with it (the timestamp will remain as zero and will never
+      get resolved)
+   Because of the limitations above, two timestamp buffers are managed internally. Once one
+   of the buffers fills up with requests, the second buffer can start serving new requests.
+   Once all requests in a buffer get resolved and collected, the entire buffer is discarded
+   and a new one allocated for future requests. (Proper cycling through a ring buffer would
+   require bookkeeping and completion handlers to collect only the known complete queries.)
+   In the current implementation, there is potential for a race condition when the buffer is
+   discarded and reallocated. In practice, the race condition will never materialize so long
+   as TracyMetalCollect() is called frequently to keep the amount of unresolved queries low.
+   Finally, there's a timeout mechanism during timestamp collection to detect "empty" command
+   encoders and ensure progress.
+*/
+
+#ifndef TRACY_ENABLE
+
+#define TracyMetalContext(device) nullptr
+#define TracyMetalDestroy(ctx)
+#define TracyMetalContextName(ctx, name, size)
+
+#define TracyMetalZone(ctx, encoderDesc, name)
+#define TracyMetalZoneC(ctx, encoderDesc, name, color)
+#define TracyMetalNamedZone(ctx, varname, encoderDesc, name, active)
+#define TracyMetalNamedZoneC(ctx, varname, encoderDesc, name, color, active)
+
+#define TracyMetalCollect(ctx)
+
+namespace tracy
+{
+class MetalZoneScope {};
+}
+
+using TracyMetalCtx = void;
+
+#else
+
+#if not __has_feature(objc_arc)
+#error TracyMetal requires ARC to be enabled.
+#endif
+
+#include <atomic>
+#include <cassert>
+#include <cstdlib>
+
+#include "Tracy.hpp"
+#include "../client/TracyProfiler.hpp"
+#include "../client/TracyCallstack.hpp"
+#include "../common/TracyAlign.hpp"
+#include "../common/TracyAlloc.hpp"
+
+// ok to import if in obj-c code
+#import <Metal/Metal.h>
+
+#define TRACY_METAL_VA_ARGS(...) , ##__VA_ARGS__
+
+#define TracyMetalPanic(ret, msg, ...) do { \
+    char buffer [1024]; \
+    snprintf(buffer, sizeof(buffer), "TracyMetal: " msg TRACY_METAL_VA_ARGS(__VA_ARGS__)); \
+    TracyMessageC(buffer, strlen(buffer), tracy::Color::OrangeRed); \
+    fprintf(stderr, "%s\n", buffer); \
+    ret; \
+    } while(false);
+
+#ifndef TRACY_METAL_TIMESTAMP_COLLECT_TIMEOUT
+#define TRACY_METAL_TIMESTAMP_COLLECT_TIMEOUT 0.200f
+#endif//TRACY_METAL_TIMESTAMP_COLLECT_TIMEOUT
+
+#ifndef TRACY_METAL_DEBUG_MASK
+#define TRACY_METAL_DEBUG_MASK (0)
+#endif//TRACY_METAL_DEBUG_MASK
+
+#if TRACY_METAL_DEBUG_MASK
+    #define TracyMetalDebugMasked(mask, ...) if constexpr (mask & TRACY_METAL_DEBUG_MASK) { __VA_ARGS__; }
+#else
+    #define TracyMetalDebugMasked(mask, ...)
+#endif
+
+#if TRACY_METAL_DEBUG_MASK & (1 << 1)
+    #define TracyMetalDebug_0b00010(...) __VA_ARGS__;
+#else
+    #define TracyMetalDebug_0b00010(...)
+#endif
+
+#if TRACY_METAL_DEBUG_MASK & (1 << 4)
+    #define TracyMetalDebug_0b10000(...) __VA_ARGS__;
+#else
+    #define TracyMetalDebug_0b10000(...)
+#endif
+
+#ifndef TracyMetalDebugZoneScopeWireTap
+#define TracyMetalDebugZoneScopeWireTap
+#endif//TracyMetalDebugZoneScopeWireTap
+
+namespace tracy
+{
+
+class MetalCtx
+{
+    friend class MetalZoneScope;
+
+    enum { MaxQueries = 4 * 1024 };    // Metal: between 8 and 32768 _BYTES_...
+
+public:
+    static MetalCtx* Create(id<MTLDevice> device)
+    {
+        ZoneScopedNC("tracy::MetalCtx::Create", Color::Red4);
+        auto ctx = static_cast<MetalCtx*>(tracy_malloc(sizeof(MetalCtx)));
+        new (ctx) MetalCtx(device);
+        if (ctx->m_contextId == 255)
+        {
+            TracyMetalPanic({assert(false);} return nullptr, "ERROR: unable to create context.");
+            Destroy(ctx);
+        }
+        return ctx;
+    }
+
+    static void Destroy(MetalCtx* ctx)
+    {
+        ZoneScopedNC("tracy::MetalCtx::Destroy", Color::Red4);
+        ctx->~MetalCtx();
+        tracy_free(ctx);
+    }
+
+    void Name( const char* name, uint16_t len )
+    {
+        auto ptr = (char*)tracy_malloc( len );
+        memcpy( ptr, name, len );
+
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuContextName );
+        MemWrite( &item->gpuContextNameFat.context, m_contextId );
+        MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
+        MemWrite( &item->gpuContextNameFat.size, len );
+        SubmitQueueItem(item);
+    }
+
+    bool Collect()
+    {
+        ZoneScopedNC("tracy::MetalCtx::Collect", Color::Red4);
+
+#ifdef TRACY_ON_DEMAND
+        if (!GetProfiler().IsConnected())
+        {
+            return true;
+        }
+#endif
+
+        // Only one thread is allowed to collect timestamps at any given time
+        // but there's no need to block contending threads
+        if (!m_collectionMutex.try_lock())
+        {
+            return true;
+        }
+
+        std::unique_lock lock (m_collectionMutex, std::adopt_lock);
+
+        uintptr_t begin = m_previousCheckpoint.load();
+        uintptr_t latestCheckpoint = m_queryCounter.load(); // TODO: MTLEvent? MTLFence?;
+        TracyMetalDebugMasked(1<<3, ZoneValue(begin));
+        TracyMetalDebugMasked(1<<3, ZoneValue(latestCheckpoint));
+
+        uint32_t count = RingCount(begin, latestCheckpoint);
+        if (count == 0)   // no pending timestamp queries
+        {
+            //uintptr_t nextCheckpoint = m_queryCounter.load();
+            //if (nextCheckpoint != latestCheckpoint)
+            //{
+            //    // TODO: signal event / fence now?
+            //}
+            return true;
+        }
+
+        // resolve up until the ring buffer boundary and let a subsequenty call
+        // to Collect handle the wrap-around
+        bool reallocateBuffer = false;
+        if (RingIndex(begin) + count >= RingSize())
+        {
+            count = RingSize() - RingIndex(begin);
+            reallocateBuffer = true;
+        }
+        TracyMetalDebugMasked(1<<3, ZoneValue(count));
+        
+        auto buffer_idx = (begin / MaxQueries) % 2;
+        auto counterSampleBuffer = m_counterSampleBuffers[buffer_idx];
+
+        if (count >= RingSize())
+        {
+            TracyMetalPanic(return false, "Collect: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", begin, latestCheckpoint, count);
+        }
+
+        TracyMetalDebugMasked(1<<3, TracyMetalPanic(, "Collect: [%llu, %llu] :: (%u)", begin, latestCheckpoint, count));
+
+        NSRange range = NSMakeRange(RingIndex(begin), count);
+        NSData* data = [counterSampleBuffer resolveCounterRange:range];
+        NSUInteger numResolvedTimestamps = data.length / sizeof(MTLCounterResultTimestamp);
+        MTLCounterResultTimestamp* timestamps = (MTLCounterResultTimestamp *)(data.bytes);
+        if (timestamps == nil)
+        {
+            TracyMetalPanic(return false, "Collect: unable to resolve timestamps.");
+        }
+
+        if (numResolvedTimestamps != count)
+        {
+            TracyMetalPanic(, "Collect: numResolvedTimestamps != count : %u != %u", (uint32_t)numResolvedTimestamps, count);
+        }
+
+        int resolved = 0;
+        for (auto i = 0; i < numResolvedTimestamps; i += 2)
+        {
+            TracyMetalDebug_0b10000( ZoneScopedN("tracy::MetalCtx::Collect::[i]") );
+            MTLTimestamp t_start = timestamps[i+0].timestamp;
+            MTLTimestamp t_end = timestamps[i+1].timestamp;
+            uint32_t k = RingIndex(begin + i);
+            TracyMetalDebugMasked(1<<4, TracyMetalPanic(, "Collect: timestamp[%u] = %llu | timestamp[%u] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start)));
+            if ((t_start == MTLCounterErrorValue)  || (t_end == MTLCounterErrorValue))
+            {
+                TracyMetalPanic(, "Collect: invalid timestamp (MTLCounterErrorValue) at %u.", k);
+                break;
+            }
+            // Metal will initialize timestamp buffer with zeroes; encountering a zero-value
+            // timestamp means that the timestamp has not been written and resolved yet
+            if ((t_start == 0) || (t_end == 0))
+            {
+                auto checkTime = std::chrono::high_resolution_clock::now();
+                auto requestTime = m_timestampRequestTime[k];
+                auto ms_in_flight = std::chrono::duration<float>(checkTime-requestTime).count()*1000.0f;
+                TracyMetalDebugMasked(1<<4, TracyMetalPanic(, "Collect: invalid timestamp (zero) at %u [%.0fms in flight].", k, ms_in_flight));
+                const float timeout_ms = TRACY_METAL_TIMESTAMP_COLLECT_TIMEOUT * 1000.0f;
+                if (ms_in_flight < timeout_ms)
+                    break;
+                TracyMetalDebug_0b10000( ZoneScopedN("tracy::MetalCtx::Collect::Drop") );
+                TracyMetalPanic(, "Collect: giving up on timestamp at %u [%.0fms in flight].", k, ms_in_flight);
+                t_start = m_mostRecentTimestamp + 5;
+                t_end = t_start + 5;
+            }
+            TracyMetalDebugMasked(1<<2, TracyFreeN((void*)(uintptr_t)(k+0), "TracyMetalGpuZone"));
+            TracyMetalDebugMasked(1<<2, TracyFreeN((void*)(uintptr_t)(k+1), "TracyMetalGpuZone"));
+            {
+            auto* item = Profiler::QueueSerial();
+            MemWrite(&item->hdr.type, QueueType::GpuTime);
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_start));
+            MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k));
+            MemWrite(&item->gpuTime.context, m_contextId);
+            Profiler::QueueSerialFinish();
+            }
+            {
+            auto* item = Profiler::QueueSerial();
+            MemWrite(&item->hdr.type, QueueType::GpuTime);
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_end));
+            MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k+1));
+            MemWrite(&item->gpuTime.context, m_contextId);
+            Profiler::QueueSerialFinish();
+            }
+            m_mostRecentTimestamp = (t_end > m_mostRecentTimestamp) ? t_end : m_mostRecentTimestamp;
+            TracyMetalDebugMasked(1<<1, TracyFreeN((void*)(uintptr_t)k, "TracyMetalTimestampQueryId"));
+            resolved += 2;
+        }
+        TracyMetalDebugMasked(1<<3, ZoneValue(RingCount(begin, m_previousCheckpoint.load())));
+        
+        m_previousCheckpoint += resolved;
+        
+        // Check whether the timestamp buffer has been fully resolved/collected:
+        // WARN: there's technically a race condition here: NextQuery() may reference the
+        // buffer that is being released instead of the new one. In practice, this should
+        // never happen so long as Collect is called frequently enough to prevent pending
+        // timestamp query requests from piling up too quickly.
+        if ((resolved == count) && (m_previousCheckpoint.load() % MaxQueries) == 0)
+        {
+            m_counterSampleBuffers[buffer_idx] = NewTimestampSampleBuffer(m_device, MaxQueries);
+        }
+
+        //RecalibrateClocks();    // to account for drift
+
+        return true;
+    }
+
+private:
+    MetalCtx(id<MTLDevice> device)
+    : m_device(device)
+    {
+        TracyMetalDebugMasked(1<<0, TracyMetalPanic(, "MTLCounterErrorValue = 0x%llx", MTLCounterErrorValue));
+        TracyMetalDebugMasked(1<<0, TracyMetalPanic(, "MTLCounterDontSample = 0x%llx", MTLCounterDontSample));
+        
+        if (m_device == nil)
+        {
+            TracyMetalPanic({assert(false);} return, "device is nil.");
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtStageBoundary])
+        {
+            TracyMetalPanic({assert(false);} return, "ERROR: timestamp sampling at pipeline stage boundary is not supported.");
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDrawBoundary])
+        {
+            TracyMetalDebugMasked(1<<0, fprintf(stderr, "WARNING: timestamp sampling at draw call boundary is not supported.\n"));
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtBlitBoundary])
+        {
+            TracyMetalDebugMasked(1<<0, fprintf(stderr, "WARNING: timestamp sampling at blit boundary is not supported.\n"));
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDispatchBoundary])
+        {
+            TracyMetalDebugMasked(1<<0, fprintf(stderr, "WARNING: timestamp sampling at compute dispatch boundary is not supported.\n"));
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtTileDispatchBoundary])
+        {
+            TracyMetalDebugMasked(1<<0, fprintf(stderr, "WARNING: timestamp sampling at tile dispatch boundary is not supported.\n"));
+        }
+        
+        m_counterSampleBuffers[0] = NewTimestampSampleBuffer(m_device, MaxQueries);
+        m_counterSampleBuffers[1] = NewTimestampSampleBuffer(m_device, MaxQueries);
+        
+        m_timestampRequestTime.resize(MaxQueries);
+
+        MTLTimestamp cpuTimestamp = 0;
+        MTLTimestamp gpuTimestamp = 0;
+        [m_device sampleTimestamps:&cpuTimestamp gpuTimestamp:&gpuTimestamp];
+        m_mostRecentTimestamp = gpuTimestamp;
+        TracyMetalDebugMasked(1<<0, TracyMetalPanic(, "Calibration: CPU timestamp (Metal): %llu", cpuTimestamp));
+        TracyMetalDebugMasked(1<<0, TracyMetalPanic(, "Calibration: GPU timestamp (Metal): %llu", gpuTimestamp));
+
+        cpuTimestamp = Profiler::GetTime();
+        TracyMetalDebugMasked(1<<0, TracyMetalPanic(, "Calibration: CPU timestamp (Tracy): %llu", cpuTimestamp));
+
+        float period = 1.0f;
+        
+        m_contextId = GetGpuCtxCounter().fetch_add(1);
+        
+        auto* item = Profiler::QueueSerial();
+        MemWrite(&item->hdr.type, QueueType::GpuNewContext);
+        MemWrite(&item->gpuNewContext.cpuTime, int64_t(cpuTimestamp));
+        MemWrite(&item->gpuNewContext.gpuTime, int64_t(gpuTimestamp));
+        MemWrite(&item->gpuNewContext.thread, uint32_t(0)); // TODO: why not GetThreadHandle()?
+        MemWrite(&item->gpuNewContext.period, period);
+        MemWrite(&item->gpuNewContext.context, m_contextId);
+        //MemWrite(&item->gpuNewContext.flags, GpuContextCalibration);
+        MemWrite(&item->gpuNewContext.flags, GpuContextFlags(0));
+        MemWrite(&item->gpuNewContext.type, GpuContextType::Metal);
+        SubmitQueueItem(item);
+    }
+
+    ~MetalCtx()
+    {
+        // collect the last remnants of Metal GPU activity...
+        // TODO: add a timeout to this loop?
+        while (m_previousCheckpoint.load() != m_queryCounter.load())
+            Collect();
+    }
+
+    tracy_force_inline void SubmitQueueItem(QueueItem* item)
+    {
+#ifdef TRACY_ON_DEMAND
+        GetProfiler().DeferItem(*item);
+#endif
+        Profiler::QueueSerialFinish();
+    }
+
+    tracy_force_inline uint32_t RingIndex(uintptr_t index)
+    {
+        index %= MaxQueries;
+        return static_cast<uint32_t>(index);
+    }
+
+    tracy_force_inline uint32_t RingCount(uintptr_t begin, uintptr_t end)
+    {
+        // wrap-around safe: all unsigned
+        uintptr_t count = end - begin;
+        return static_cast<uint32_t>(count);
+    }
+
+    tracy_force_inline uint32_t RingSize() const
+    {
+        return MaxQueries;
+    }
+
+    struct Query { id<MTLCounterSampleBuffer> buffer; uint32_t idx; };
+
+    tracy_force_inline Query NextQuery()
+    {
+        TracyMetalDebug_0b00010( ZoneScopedNC("Tracy::MetalCtx::NextQuery", tracy::Color::LightCoral) );
+        auto id = m_queryCounter.fetch_add(2);
+        TracyMetalDebug_0b00010( ZoneValue(id) );
+        auto count = RingCount(m_previousCheckpoint, id);
+        if (count >= MaxQueries)
+        {
+            // TODO: return a proper (hidden) "sentinel" query
+            Query sentinel = Query{ m_counterSampleBuffers[1], MaxQueries-2 };
+            TracyMetalPanic(
+                return sentinel,
+                "NextQueryId: FULL! too many pending timestamp queries. Consider calling TracyMetalCollect() more frequently. [%llu, %llu] (%u)",
+                m_previousCheckpoint.load(), id, count
+            );
+        }
+        uint32_t buffer_idx = (id / MaxQueries) % 2;
+        TracyMetalDebug_0b00010( ZoneValue(buffer_idx) );
+        auto buffer = m_counterSampleBuffers[buffer_idx];
+        if (buffer == nil)
+            TracyMetalPanic(, "NextQueryId: sample buffer is nil! (id=%llu)", id);
+        uint32_t idx = RingIndex(id);
+        TracyMetalDebug_0b00010( ZoneValue(idx) );
+        TracyMetalDebug_0b00010( TracyAllocN((void*)(uintptr_t)idx, 2, "TracyMetalTimestampQueryId") );
+        m_timestampRequestTime[idx] = std::chrono::high_resolution_clock::now();
+        return Query{ buffer, idx };
+    }
+
+    tracy_force_inline uint8_t GetContextId() const
+    {
+        return m_contextId;
+    }
+    
+    static id<MTLCounterSampleBuffer> NewTimestampSampleBuffer(id<MTLDevice> device, size_t count)
+    {
+        ZoneScopedN("tracy::MetalCtx::NewTimestampSampleBuffer");
+
+        id<MTLCounterSet> timestampCounterSet = nil;
+        for (id<MTLCounterSet> counterSet in device.counterSets)
+        {
+            if ([counterSet.name isEqualToString:MTLCommonCounterSetTimestamp])
+            {
+                timestampCounterSet = counterSet;
+                break;
+            }
+        }
+        if (timestampCounterSet == nil)
+        {
+            TracyMetalPanic({assert(false);} return nil, "ERROR: timestamp counters are not supported on the platform.");
+        }
+
+        MTLCounterSampleBufferDescriptor* sampleDescriptor = [[MTLCounterSampleBufferDescriptor alloc] init];
+        sampleDescriptor.counterSet = timestampCounterSet;
+        sampleDescriptor.sampleCount = MaxQueries;
+        sampleDescriptor.storageMode = MTLStorageModeShared;
+        sampleDescriptor.label = @"TracyMetalTimestampPool";
+
+        NSError* error = nil;
+        id<MTLCounterSampleBuffer> counterSampleBuffer = [device newCounterSampleBufferWithDescriptor:sampleDescriptor error:&error];
+        if (error != nil)
+        {
+            //NSLog(@"%@ | %@", error.localizedDescription, error.localizedFailureReason);
+            TracyMetalPanic({assert(false);} return nil,
+                "ERROR: unable to create sample buffer for timestamp counters : %s | %s",
+                [error.localizedDescription cString], [error.localizedFailureReason cString]);
+        }
+        
+        return counterSampleBuffer;
+    }
+
+    uint8_t m_contextId = 255;
+
+    id<MTLDevice> m_device = nil;
+    id<MTLCounterSampleBuffer> m_counterSampleBuffers [2] = {};
+
+    using atomic_counter = std::atomic<uintptr_t>;
+    static_assert(atomic_counter::is_always_lock_free);
+    atomic_counter m_queryCounter = 0;
+
+    atomic_counter m_previousCheckpoint = 0;
+    MTLTimestamp m_mostRecentTimestamp = 0;
+    
+    std::vector<std::chrono::high_resolution_clock::time_point> m_timestampRequestTime;
+    
+    std::mutex m_collectionMutex;
+};
+
+class MetalZoneScope
+{
+public:
+    tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLComputePassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
+#ifdef TRACY_ON_DEMAND
+        : m_active( is_active && GetProfiler().IsConnected() )
+#else
+        : m_active( is_active )
+#endif
+    {
+        if ( !m_active ) return;
+        if (desc == nil) TracyMetalPanic({assert(false);} return, "compute pass descriptor is nil.");
+        m_ctx = ctx;
+
+        auto& query = m_query = ctx->NextQuery();
+
+        desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
+        desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = query.idx+0;
+        desc.sampleBufferAttachments[0].endOfEncoderSampleIndex   = query.idx+1;
+
+        SubmitZoneBeginGpu(ctx, query.idx + 0, srcloc);
+    }
+
+    tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLBlitPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
+#ifdef TRACY_ON_DEMAND
+        : m_active( is_active && GetProfiler().IsConnected() )
+#else
+        : m_active( is_active )
+#endif
+    {
+        if ( !m_active ) return;
+        if (desc == nil) TracyMetalPanic({assert(false); }return, "blit pass descriptor is nil.");
+        m_ctx = ctx;
+
+        auto& query = m_query = ctx->NextQuery();
+
+        desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
+        desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = query.idx+0;
+        desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = query.idx+1;
+
+        SubmitZoneBeginGpu(ctx, query.idx + 0, srcloc);
+    }
+
+    tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLRenderPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
+#ifdef TRACY_ON_DEMAND
+        : m_active( is_active && GetProfiler().IsConnected() )
+#else
+        : m_active( is_active )
+#endif
+    {
+        if ( !m_active ) return;
+        if (desc == nil) TracyMetalPanic({assert(false);} return, "render pass descriptor is nil.");
+        m_ctx = ctx;
+
+        auto& query = m_query = ctx->NextQuery();
+
+        desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
+        desc.sampleBufferAttachments[0].startOfVertexSampleIndex = query.idx+0;
+        desc.sampleBufferAttachments[0].endOfVertexSampleIndex = MTLCounterDontSample;
+        desc.sampleBufferAttachments[0].startOfFragmentSampleIndex = MTLCounterDontSample;
+        desc.sampleBufferAttachments[0].endOfFragmentSampleIndex = query.idx+1;
+
+        SubmitZoneBeginGpu(ctx, query.idx + 0, srcloc);
+    }
+
+    /* TODO: implement this constructor interfarce for "command-level" profiling, if the device supports it
+    tracy_force_inline MetalZoneScope( MetalCtx* ctx, id<MTLComputeCommandEncoder> cmdEncoder, const SourceLocationData* srcloc, bool is_active )
+#ifdef TRACY_ON_DEMAND
+        : m_active( is_active && GetProfiler().IsConnected() )
+#else
+        : m_active( is_active )
+#endif
+    {
+        if( !m_active ) return;
+        m_ctx = ctx;
+        m_cmdEncoder = cmdEncoder;
+
+        auto& query = m_query = ctx->NextQueryId();
+
+        [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:query.idx withBarrier:YES];
+
+        SubmitZoneBeginGpu(ctx, query.idx, srcloc);
+    }
+    */
+
+    tracy_force_inline ~MetalZoneScope()
+    {
+        if( !m_active ) return;
+
+        SubmitZoneEndGpu(m_ctx, m_query.idx + 1);
+    }
+    
+    TracyMetalDebugZoneScopeWireTap;
+
+private:
+    const bool m_active;
+
+    MetalCtx* m_ctx;
+
+    /* TODO: declare it for "command-level" profiling
+    id<MTLComputeCommandEncoder> m_cmdEncoder;
+    */
+    
+    static void SubmitZoneBeginGpu(MetalCtx* ctx, uint32_t queryId, const SourceLocationData* srcloc)
+    {
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
+        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
+        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
+        Profiler::QueueSerialFinish();
+        
+        TracyMetalDebugMasked(1<<2, TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone"));
+    }
+    
+    static void SubmitZoneEndGpu(MetalCtx* ctx, uint32_t queryId)
+    {
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneEndSerial );
+        MemWrite( &item->gpuZoneEnd.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneEnd.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneEnd.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneEnd.context, ctx->GetContextId() );
+        Profiler::QueueSerialFinish();
+        
+        TracyMetalDebugMasked(1<<2, TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone"));
+    }
+
+    MetalCtx::Query m_query = {};
+};
+
+}
+
+using TracyMetalCtx = tracy::MetalCtx;
+
+#define TracyMetalContext(device) tracy::MetalCtx::Create(device)
+#define TracyMetalDestroy(ctx) tracy::MetalCtx::Destroy(ctx)
+#define TracyMetalContextName(ctx, name, size) ctx->Name(name, size)
+
+#define TracyMetalZone( ctx, encoderDesc, name ) TracyMetalNamedZone( ctx, ___tracy_gpu_zone, encoderDesc, name, true )
+#define TracyMetalZoneC( ctx, encoderDesc, name, color ) TracyMetalNamedZoneC( ctx, ___tracy_gpu_zone, encoderDesc, name, color, true )
+#define TracyMetalNamedZone( ctx, varname, encoderDesc, name, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::MetalZoneScope varname( ctx, encoderDesc, &TracyConcat(__tracy_gpu_source_location,TracyLine), active );
+#define TracyMetalNamedZoneC( ctx, varname, encoderDesc, name, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location,TracyLine) { name, TracyFunction, TracyFile, (uint32_t)TracyLine, color }; tracy::MetalZoneScope varname( ctx, encoderDesc, &TracyConcat(__tracy_gpu_source_location,TracyLine), active );
+
+#define TracyMetalCollect( ctx ) ctx->Collect();
+
+
+
+#undef TracyMetalDebug_ZoneScopeWireTap
+#undef TracyMetalDebug_0b00010
+#undef TracyMetalDebug_0b10000
+#undef TracyMetalDebugMasked
+#undef TRACY_METAL_DEBUG_MASK
+#undef TRACY_METAL_TIMESTAMP_COLLECT_TIMEOUT
+#undef TracyMetalPanic
+#undef TRACY_METAL_VA_ARGS
+
+#endif
+
+#endif//__TRACYMETAL_HMM__

--- a/tracy-client-sys/tracy/tracy/TracyOpenCL.hpp
+++ b/tracy-client-sys/tracy/tracy/TracyOpenCL.hpp
@@ -255,7 +255,7 @@ namespace tracy {
             Profiler::QueueSerialFinish();
         }
 
-        tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, const SourceLocationData* srcLoc, int depth, bool is_active)
+        tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, const SourceLocationData* srcLoc, int32_t depth, bool is_active)
 #ifdef TRACY_ON_DEMAND
             : m_active(is_active&& GetProfiler().IsConnected())
 #else
@@ -304,7 +304,7 @@ namespace tracy {
             Profiler::QueueSerialFinish();
         }
 
-        tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool is_active)
+        tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool is_active)
 #ifdef TRACY_ON_DEMAND
             : m_active(is_active && GetProfiler().IsConnected())
 #else

--- a/tracy-client-sys/tracy/tracy/TracyOpenGL.hpp
+++ b/tracy-client-sys/tracy/tracy/TracyOpenGL.hpp
@@ -25,7 +25,7 @@ class GpuCtxScope
 {
 public:
     GpuCtxScope( const SourceLocationData*, bool ) {}
-    GpuCtxScope( const SourceLocationData*, int, bool ) {}
+    GpuCtxScope( const SourceLocationData*, int32_t, bool ) {}
 };
 }
 
@@ -222,7 +222,7 @@ public:
         TracyLfqCommit;
     }
 
-    tracy_force_inline GpuCtxScope( const SourceLocationData* srcloc, int depth, bool is_active )
+    tracy_force_inline GpuCtxScope( const SourceLocationData* srcloc, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else
@@ -271,7 +271,7 @@ public:
         TracyLfqCommit;
     }
 
-    tracy_force_inline GpuCtxScope( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool is_active )
+    tracy_force_inline GpuCtxScope( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else

--- a/tracy-client/Cargo.toml
+++ b/tracy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracy-client"
-version = "0.18.0" # AUTO-BUMP
+version = "0.18.1" # AUTO-BUMP
 authors = ["Simonas Kazlauskas <tracy-client@kazlauskas.me>"]
 license.workspace = true
 edition.workspace = true
@@ -38,7 +38,7 @@ rustc-demangle = { version = "0.1", optional = true }
 [dependencies.sys]
 path = "../tracy-client-sys"
 package = "tracy-client-sys"
-version = ">=0.23.0, <0.25.0" # AUTO-UPDATE
+version = ">=0.23.0, <0.26.0" # AUTO-UPDATE
 default-features = false
 
 [target.'cfg(loom)'.dependencies.loom]


### PR DESCRIPTION
This pull request introduces updates across several areas of the project, including workflow adjustments, Rust toolchain upgrades, documentation updates, and significant changes to the `tracy-client-sys` library. The most notable changes involve improvements to crash handling, memory safety, and profiling features in `tracy-client-sys`. Below is a summary of the most important changes grouped by theme.

### Workflow Updates:
* [`.github/workflows/sys-update.yml`](diffhunk://#diff-97f55315c98095d9492ba8102fc0ddd384d4ee726b51c31065e71bd9efc2ffb6L12-R12): Updated action versions and parameters for `actions/checkout`, `actions/create-github-app-token`, and `peter-evans/create-pull-request`. Added branch naming to pull request creation. [[1]](diffhunk://#diff-97f55315c98095d9492ba8102fc0ddd384d4ee726b51c31065e71bd9efc2ffb6L12-R12) [[2]](diffhunk://#diff-97f55315c98095d9492ba8102fc0ddd384d4ee726b51c31065e71bd9efc2ffb6L21-L35)
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L17-R17): Upgraded Rust toolchain matrix to include version `1.81.0`.

### Documentation and Metadata:
* [`README.mkd`](diffhunk://#diff-209583b18067287163ba006fb3a67ba63d72d374f225fe4776e246e47724c875R60): Added version correspondence for `v0.12.0` in the library table.
* [`tracy-client-sys/Cargo.toml`](diffhunk://#diff-8d3b3f55bd2554a409168596cdfac2f176f3e7ae63f3bce39739b4021d9ff356L3-R3): Bumped version from `0.24.3` to `0.25.0`.
* [`tracy-client-sys/tracy/LICENSE`](diffhunk://#diff-01ae63433e894412c57e5cbbc89e009150b953d14049bab060fd9a329a7cf426L4-R4): Updated copyright year to `2025`.

### Profiling Enhancements:
* [`tracy-client-sys/tracy/client/TracyCallstack.cpp`](diffhunk://#diff-b3b2a3ed73b21a0352097fd43c8317dd2ce8f517a231d298cdf8f5cb0289cfdcL285-R290): Refactored `___tracy_RtlWalkFrameChain` to use a pointer-based implementation for better flexibility. [[1]](diffhunk://#diff-b3b2a3ed73b21a0352097fd43c8317dd2ce8f517a231d298cdf8f5cb0289cfdcL285-R290) [[2]](diffhunk://#diff-b3b2a3ed73b21a0352097fd43c8317dd2ce8f517a231d298cdf8f5cb0289cfdcL310-R315)
* [`tracy-client-sys/tracy/client/TracyProfiler.cpp`](diffhunk://#diff-649a8b817db63f239eaa85abc3c5e3e411f3ea933ba13da1155e0bca6a53b525R531-R540): Introduced safe memory copying via `SafeCopyProlog` and `SafeCopyEpilog` methods to handle potential unsafe memory accesses. Added support for Wine detection in host information. Improved crash handler installation and removal mechanisms. [[1]](diffhunk://#diff-649a8b817db63f239eaa85abc3c5e3e411f3ea933ba13da1155e0bca6a53b525R531-R540) [[2]](diffhunk://#diff-649a8b817db63f239eaa85abc3c5e3e411f3ea933ba13da1155e0bca6a53b525R1397-R1398) [[3]](diffhunk://#diff-649a8b817db63f239eaa85abc3c5e3e411f3ea933ba13da1155e0bca6a53b525L1479-R1514) [[4]](diffhunk://#diff-649a8b817db63f239eaa85abc3c5e3e411f3ea933ba13da1155e0bca6a53b525L1490-R1547) [[5]](diffhunk://#diff-649a8b817db63f239eaa85abc3c5e3e411f3ea933ba13da1155e0bca6a53b525R3114-R3169)

### Bindgen and Build Process:
* [`make_sys.sh`](diffhunk://#diff-eba0e596542e5c2a74a0a7c998fa4a6ff92a5953b5e3281583ac8c6af89a01f9L20-R20): Updated `bindgen` commands to specify `--rust-target 1.70.0`. Replaced deprecated GitHub Actions output syntax with `GITHUB_OUTPUT`. [[1]](diffhunk://#diff-eba0e596542e5c2a74a0a7c998fa4a6ff92a5953b5e3281583ac8c6af89a01f9L20-R20) [[2]](diffhunk://#diff-eba0e596542e5c2a74a0a7c998fa4a6ff92a5953b5e3281583ac8c6af89a01f9R37-R51) [[3]](diffhunk://#diff-eba0e596542e5c2a74a0a7c998fa4a6ff92a5953b5e3281583ac8c6af89a01f9L60-R63)

### Code Refinements:
* [`tracy-client-sys/tracy/client/TracyCallstack.hpp`](diffhunk://#diff-96315e7e0b2a44033fb622b04f9cbb62ca6b4880078fd6d6e33eb605720c7e12L12-R13): Enhanced `Callstack` function signatures to use `int32_t` for consistency and added `has_callstack` constexpr functions. [[1]](diffhunk://#diff-96315e7e0b2a44033fb622b04f9cbb62ca6b4880078fd6d6e33eb605720c7e12L12-R13) [[2]](diffhunk://#diff-96315e7e0b2a44033fb622b04f9cbb62ca6b4880078fd6d6e33eb605720c7e12R42-R43) [[3]](diffhunk://#diff-96315e7e0b2a44033fb622b04f9cbb62ca6b4880078fd6d6e33eb605720c7e12L82-R88) [[4]](diffhunk://#diff-96315e7e0b2a44033fb622b04f9cbb62ca6b4880078fd6d6e33eb605720c7e12L115-R117) [[5]](diffhunk://#diff-96315e7e0b2a44033fb622b04f9cbb62ca6b4880078fd6d6e33eb605720c7e12L130-R132)